### PR TITLE
fix: 非推奨の@types/dompurifyパッケージを削除

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@react-three/drei": "^10.7.4",
         "@react-three/fiber": "^9.3.0",
         "@sentry/nextjs": "^10.5.0",
-        "@types/dompurify": "^3.0.5",
         "cheerio": "^1.1.2",
         "clsx": "^2.1.1",
         "dompurify": "^3.2.6",
@@ -4519,15 +4518,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/dompurify": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
-      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/trusted-types": "*"
-      }
-    },
     "node_modules/@types/draco3d": {
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
@@ -4796,7 +4786,8 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/webxr": {
       "version": "0.5.22",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@react-three/drei": "^10.7.4",
     "@react-three/fiber": "^9.3.0",
     "@sentry/nextjs": "^10.5.0",
-    "@types/dompurify": "^3.0.5",
     "cheerio": "^1.1.2",
     "clsx": "^2.1.1",
     "dompurify": "^3.2.6",


### PR DESCRIPTION
## 概要
PR #18のDependabot更新に対するClaudeレビューで指摘された問題を解決します。

## 背景
`@types/dompurify`パッケージが非推奨（deprecated）になっています：
```
"This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed."
```

## 変更内容
- `@types/dompurify`パッケージを完全に削除
- dompurify v3.x の内蔵型定義を使用

## 確認項目
✅ TypeScript型チェック通過（`npm run type-check`）
✅ 全テスト通過（`npm test` - 76 tests passed）
✅ ビルド成功確認

## 関連Issue/PR
- Closes #18 (Dependabotの更新を不要にする)
- Claudeレビューの指摘事項を解決

## 影響
- 型安全性への影響なし（むしろ改善）
- バンドルサイズわずかに削減
- 依存関係のクリーンアップ

🤖 Generated with Claude Code