### PR TITLE
🚨 緊急修正2: Cloudflare FunctionsのCSPミドルウェア修正

### DIFF
--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -7,16 +7,40 @@ export async function onRequest(context) {
   // Add security headers to all responses
   const response = await next();
   
+  // Get URL path
+  const url = new URL(request.url);
+  const isApiRoute = url.pathname.startsWith('/api/');
+  
   response.headers.set('X-Content-Type-Options', 'nosniff');
   response.headers.set('X-Frame-Options', 'DENY');
   response.headers.set('X-XSS-Protection', '1; mode=block');
   response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
   
-  // Basic CSP for API responses
-  response.headers.set(
-    'Content-Security-Policy',
-    "default-src 'self'; script-src 'none'; style-src 'none';"
-  );
+  // Different CSP for API vs regular pages
+  if (isApiRoute) {
+    // Restrictive CSP for API responses
+    response.headers.set(
+      'Content-Security-Policy',
+      "default-src 'none'; frame-ancestors 'none';"
+    );
+  } else {
+    // Full CSP for web pages (matching public/_headers)
+    response.headers.set(
+      'Content-Security-Policy',
+      "default-src 'self' https://cnd2-app.pages.dev https://cnd2.cloudnativedays.jp; " +
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cnd2-app.pages.dev https://cnd2.cloudnativedays.jp https://cdn.jsdelivr.net; " +
+      "style-src 'self' 'unsafe-inline' https://cnd2-app.pages.dev https://cnd2.cloudnativedays.jp https://fonts.googleapis.com; " +
+      "font-src 'self' https://cnd2-app.pages.dev https://cnd2.cloudnativedays.jp https://fonts.gstatic.com data:; " +
+      "img-src 'self' data: https: blob:; " +
+      "connect-src 'self' https://cnd2-app.pages.dev https://cnd2.cloudnativedays.jp https://api.openai.com https://prairie.cards https://*.prairie.cards https://api.qrserver.com; " +
+      "frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;"
+    );
+    
+    response.headers.set(
+      'Permissions-Policy',
+      'camera=(), microphone=(), geolocation=(), payment=()'
+    );
+  }
   
   return response;
 }


### PR DESCRIPTION
## 🔴 緊急度：最高（本番環境がまだ動作していません）

## 問題
PR #37でpublic/_headersを修正したが、**本番環境が依然として表示されない**

### 根本原因
`functions/_middleware.js`が全てのレスポンスに制限的なCSPを上書き適用していた：
```javascript
// 問題のコード
"default-src 'self'; script-src 'none'; style-src 'none';"
```

これによりNext.jsの静的ファイルが読み込めない状態が継続。

## 解決策
ミドルウェアでAPIルートと通常ページを区別：

### APIルート（/api/*）
```javascript
"default-src 'none'; frame-ancestors 'none';"
```

### 通常ページ
```javascript  
"default-src 'self' https://cnd2-app.pages.dev https://cnd2.cloudnativedays.jp; ..."
// public/_headers と同じ設定
```

## 検証済み
- APIルート判定ロジック: `url.pathname.startsWith('/api/')`
- CSP設定が public/_headers と完全一致

## 影響範囲
- **本番環境の完全復旧**
- APIセキュリティの維持

## デプロイ後の確認事項
1. https://cnd2-app.pages.dev が正常に表示される
2. APIエンドポイントのCSPが制限的なまま維持される

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>