### PR TITLE
chore: Configure Dependabot to ignore node-fetch v3+ updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
     ignore:
       # @types/dompurify is deprecated as DOMPurify now includes its own types
       - dependency-name: "@types/dompurify"
+      # node-fetch v3+ is ESM-only and breaks our CommonJS test setup
+      - dependency-name: "node-fetch"
+        versions: [">=3.0.0"]
     groups:
       dependencies:
         patterns:


### PR DESCRIPTION
## 概要
Dependabotがnode-fetch v3以降への自動更新PRを作成しないよう設定を追加

## 背景
- PR #43, #44でnode-fetch v3への更新によりすべてのテストが失敗
- node-fetch v3はESMのみサポート（CommonJS非対応）
- 現在のテスト環境（jest.setup.js）はCommonJSを使用

## 変更内容
- `.github/dependabot.yml`にnode-fetch v3以降を無視する設定を追加
- バージョン指定: `>=3.0.0`

## 影響
- 今後Dependabotはnode-fetchのメジャーバージョン更新PRを作成しない
- セキュリティ更新は引き続き v2.x系で受け取る
- 将来的なESM移行は別途計画的に実施

## テスト
- [x] Dependabot設定のYAML構文が正しいことを確認
- [x] 既存のCI/CDパイプラインに影響なし

## 関連Issue/PR
- #43 (Closed) - 初回のnode-fetch v3更新PR（マージコンフリクトあり）
- #44 (Closed) - 2回目のnode-fetch v3更新PR（テスト失敗）