### PR TITLE
🚨 HOTFIX: DiagnosisResult型エラーを修正（本番デプロイ障害）

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -52,6 +52,12 @@ export interface DiagnosisResult {
   conversationStarters?: string[];
   hiddenGems?: string;
   shareTag?: string;
+  // V3 engine metadata
+  metadata?: {
+    engine?: string;
+    model?: string;
+    analysis?: any;
+  };
 }
 
 export interface CND2State {


### PR DESCRIPTION
緊急対応: 本番環境のデプロイが失敗しています

エラー: metadataプロパティがDiagnosisResult型に存在しない

修正: DiagnosisResult型にmetadataフィールドを追加

影響範囲: V3診断エンジンのみ、後方互換性維持

至急マージをお願いします！