### PR TITLE
fix: API client error handling for [object Object] display issue

### DIFF
--- a/src/lib/__tests__/api-client.test.ts
+++ b/src/lib/__tests__/api-client.test.ts
@@ -43,7 +43,8 @@ describe('API Client', () => {
             body: JSON.stringify({ url: 'https://prairie.cards/test' }),
           })
         );
-        expect(result).toEqual(mockResponse);
+        // API client now returns data || result for wrapped responses
+        expect(result).toEqual(mockResponse.data);
       });
 
       it('HTTPエラーの場合、エラーをスローする', async () => {
@@ -51,7 +52,7 @@ describe('API Client', () => {
         (global.fetch as jest.Mock).mockResolvedValueOnce({
           ok: false,
           status: 404,
-          json: async () => ({ error: 'Not found' }),
+          json: async () => ({ error: { message: 'Not found' } }),
         });
 
         await expect(apiClient.prairie.fetch('https://prairie.cards/test'))
@@ -105,7 +106,8 @@ describe('API Client', () => {
             body: JSON.stringify({ profiles: mockProfiles, mode: 'duo' }),
           })
         );
-        expect(result).toEqual(mockResponse);
+        // API client now returns data || result for wrapped responses
+        expect(result).toEqual(mockResponse.data);
       });
 
       it('グループ診断のリクエストを正しく送信する', async () => {
@@ -126,7 +128,8 @@ describe('API Client', () => {
             body: JSON.stringify({ profiles: groupProfiles, mode: 'group' }),
           })
         );
-        expect(result).toEqual(mockResponse);
+        // API client now returns data || result for wrapped responses
+        expect(result).toEqual(mockResponse.data);
       });
 
       it('デフォルトでduoモードを使用する', async () => {
@@ -173,7 +176,8 @@ describe('API Client', () => {
             headers: { 'Content-Type': 'application/json' },
           })
         );
-        expect(result).toEqual(mockResult);
+        // API client now returns data || result for wrapped responses
+        expect(result).toEqual(mockResult.data);
       });
 
       it('404エラーを処理する', async () => {
@@ -181,7 +185,7 @@ describe('API Client', () => {
         (global.fetch as jest.Mock).mockResolvedValueOnce({
           ok: false,
           status: 404,
-          json: async () => ({ error: 'Result not found' }),
+          json: async () => ({ error: { message: 'Result not found' } }),
         });
 
         await expect(apiClient.results.get('nonexistent'))
@@ -210,7 +214,8 @@ describe('API Client', () => {
             body: JSON.stringify(mockResult),
           })
         );
-        expect(result).toEqual(mockResponse);
+        // API client now returns data || result for wrapped responses
+        expect(result).toEqual(mockResponse.data);
       });
     });
 
@@ -233,6 +238,7 @@ describe('API Client', () => {
             headers: { 'Content-Type': 'application/json' },
           })
         );
+        // For delete, the response doesn't have a data wrapper
         expect(result).toEqual(mockResponse);
       });
     });

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -45,11 +45,15 @@ export const apiClient = {
       });
       
       if (!response.ok) {
-        const error = await response.json().catch(() => ({ error: 'Network error' }));
-        throw new Error(error.error || `HTTP error! status: ${response.status}`);
+        const errorData = await response.json().catch(() => ({ error: { message: 'Network error' } }));
+        // Handle both old format (error.error) and new format (error.error.message)
+        const errorMessage = errorData.error?.message || errorData.error || `HTTP error! status: ${response.status}`;
+        throw new Error(errorMessage);
       }
       
-      return response.json();
+      // Handle the new response format with success/data structure
+      const result = await response.json();
+      return result.data || result;
     }
   },
   
@@ -65,11 +69,15 @@ export const apiClient = {
       });
       
       if (!response.ok) {
-        const error = await response.json().catch(() => ({ error: 'Network error' }));
-        throw new Error(error.error || `HTTP error! status: ${response.status}`);
+        const errorData = await response.json().catch(() => ({ error: { message: 'Network error' } }));
+        // Handle both old format (error.error) and new format (error.error.message)
+        const errorMessage = errorData.error?.message || errorData.error || `HTTP error! status: ${response.status}`;
+        throw new Error(errorMessage);
       }
       
-      return response.json();
+      // Handle the new response format with success/data structure
+      const result = await response.json();
+      return result.data || result;
     }
   },
   
@@ -84,11 +92,13 @@ export const apiClient = {
       });
       
       if (!response.ok) {
-        const error = await response.json().catch(() => ({ error: 'Not found' }));
-        throw new Error(error.error || `HTTP error! status: ${response.status}`);
+        const errorData = await response.json().catch(() => ({ error: { message: 'Not found' } }));
+        const errorMessage = errorData.error?.message || errorData.error || `HTTP error! status: ${response.status}`;
+        throw new Error(errorMessage);
       }
       
-      return response.json();
+      const result = await response.json();
+      return result.data || result;
     },
     
     async save(result: any) {
@@ -101,11 +111,13 @@ export const apiClient = {
       });
       
       if (!response.ok) {
-        const error = await response.json().catch(() => ({ error: 'Failed to save' }));
-        throw new Error(error.error || `HTTP error! status: ${response.status}`);
+        const errorData = await response.json().catch(() => ({ error: { message: 'Failed to save' } }));
+        const errorMessage = errorData.error?.message || errorData.error || `HTTP error! status: ${response.status}`;
+        throw new Error(errorMessage);
       }
       
-      return response.json();
+      const responseData = await response.json();
+      return responseData.data || responseData;
     },
     
     async delete(id: string) {
@@ -117,11 +129,13 @@ export const apiClient = {
       });
       
       if (!response.ok) {
-        const error = await response.json().catch(() => ({ error: 'Failed to delete' }));
-        throw new Error(error.error || `HTTP error! status: ${response.status}`);
+        const errorData = await response.json().catch(() => ({ error: { message: 'Failed to delete' } }));
+        const errorMessage = errorData.error?.message || errorData.error || `HTTP error! status: ${response.status}`;
+        throw new Error(errorMessage);
       }
       
-      return response.json();
+      const responseData = await response.json();
+      return responseData.data || responseData;
     }
   }
 };

--- a/src/lib/diagnosis-engine-v4-openai-premium.ts
+++ b/src/lib/diagnosis-engine-v4-openai-premium.ts
@@ -76,8 +76,7 @@ export class AstrologicalDiagnosisEngineV4Premium {
       skills: profile.details?.skills || [],
       interests: profile.details?.interests || [],
       motto: profile.details?.motto || '',
-      tags: profile.details?.tags || [],
-      achievements: profile.details?.achievements || []
+      tags: profile.details?.tags || []
     };
   }
 


### PR DESCRIPTION
## Summary
- Fixed error message extraction in api-client.ts to handle nested error structure
- Now correctly handles both success/data wrapped responses and direct responses
- Removed achievements field from v4-openai-premium engine (type error fix)

## Problem
Production app was showing "[object Object]" error messages when Prairie Card API requests failed, instead of displaying proper error messages.

## Solution
The API client was trying to access `error.error` but the Cloudflare Functions return errors in a nested structure:
```json
{
  "success": false,
  "error": {
    "message": "...",
    "code": "...",
    "timestamp": "..."
  }
}
```

Updated error handling to correctly extract `error.error.message` and handle both old and new response formats.

## Test plan
- [x] Build passes without errors
- [x] Tested locally with Prairie Card URLs
- [x] Error messages display correctly instead of [object Object]
- [x] Successful Prairie Card loads work properly

🤖 Generated with [Claude Code](https://claude.ai/code)