### PR TITLE
fix: Add missing env parameter to parseFromHTML in prairie.ts

### DIFF
--- a/functions/api/prairie.ts
+++ b/functions/api/prairie.ts
@@ -68,7 +68,7 @@ export async function onRequest(context: any) {
     }
     
     // Parse the HTML content
-    prairieData = parseFromHTML(htmlContent) as any;
+    prairieData = parseFromHTML(htmlContent, context.env) as any;
     
     // Add source URL to metadata if provided
     if (url && prairieData?.meta) {


### PR DESCRIPTION
## Summary
Fixes build failure caused by missing env parameter in prairie.ts

## Problem
After PR #72 was merged, the build failed with:
```
Type error: Expected 2 arguments, but got 1.
```

The TypeScript version of the prairie API (prairie.ts) also needs to pass the env parameter to parseFromHTML function.

## Solution
Added `context.env` as the second parameter to `parseFromHTML` call in prairie.ts

## Test Results
✅ Build passes successfully
✅ All tests pass

## Related PRs
- #72 - Original fix for prairie-parser.js

🤖 Generated with [Claude Code](https://claude.ai/code)