### PR TITLE
fix: Update usePrairieCard to handle new API response structure

### DIFF
--- a/functions/api/prairie.ts
+++ b/functions/api/prairie.ts
@@ -68,7 +68,7 @@ export async function onRequest(context: any) {
     }
     
     // Parse the HTML content
-    prairieData = parseFromHTML(htmlContent) as any;
+    prairieData = parseFromHTML(htmlContent, context.env) as any;
     
     // Add source URL to metadata if provided
     if (url && prairieData?.meta) {

--- a/src/hooks/__tests__/usePrairieCard.test.ts
+++ b/src/hooks/__tests__/usePrairieCard.test.ts
@@ -42,17 +42,8 @@ describe('usePrairieCard', () => {
   });
 
   it('successfully fetches a profile', async () => {
+    // Mock data should be in PrairieProfile format (as returned by the API)
     const mockData = {
-      name: 'Test User',
-      title: 'Developer',
-      company: 'Test Company',
-      bio: 'Test bio',
-      skills: ['React', 'TypeScript'],
-      tags: ['dev'],
-      interests: ['coding'],
-    };
-
-    const expectedProfile = {
       basic: {
         name: 'Test User',
         title: 'Developer',
@@ -61,7 +52,7 @@ describe('usePrairieCard', () => {
         avatar: undefined,
       },
       details: {
-        tags: [],
+        tags: ['dev'],
         skills: ['React', 'TypeScript'],
         interests: ['coding'],
         certifications: [],
@@ -77,6 +68,9 @@ describe('usePrairieCard', () => {
         hashtag: undefined,
       },
     };
+
+    // Expected profile is the same as mock data since no transformation is done
+    const expectedProfile = mockData;
 
     (apiClient.prairie.fetch as jest.Mock).mockResolvedValueOnce(mockData);
 

--- a/src/hooks/usePrairieCard.ts
+++ b/src/hooks/usePrairieCard.ts
@@ -2,7 +2,6 @@ import { useState, useCallback } from 'react';
 import { PrairieProfile } from '@/types';
 import { logger } from '@/lib/logger';
 import { apiClient } from '@/lib/api-client';
-import { MinimalProfile } from '@/lib/prairie-profile-extractor';
 
 interface UsePrairieCardReturn {
   loading: boolean;
@@ -22,38 +21,15 @@ export function usePrairieCard(): UsePrairieCardReturn {
     setError(null);
     
     try {
-      const data: MinimalProfile = await apiClient.prairie.fetch(url);
+      const response = await apiClient.prairie.fetch(url);
       
-      if (!data || !data.name) {
+      // Check if response has the expected structure
+      if (!response || !response.basic || !response.basic.name) {
         throw new Error('Prairie Cardの取得に失敗しました');
       }
 
-      // APIレスポンスをPrairieProfile形式に変換
-      const prairieProfile: PrairieProfile = {
-        basic: {
-          name: data.name || '名前未設定',
-          title: data.title || '',
-          company: data.company || '',
-          bio: data.bio || '',
-          avatar: undefined,
-        },
-        details: {
-          tags: [],
-          skills: data.skills || [],
-          interests: data.interests || [],
-          certifications: [],
-          communities: [],
-          motto: data.motto,
-        },
-        social: {},
-        custom: {},
-        meta: {
-          createdAt: undefined,
-          updatedAt: undefined,
-          connectedBy: undefined,
-          hashtag: undefined,
-        },
-      };
+      // The response is already in PrairieProfile format from the API
+      const prairieProfile: PrairieProfile = response;
 
       setProfile(prairieProfile);
       return prairieProfile;


### PR DESCRIPTION
## Summary
Final fix to make Prairie Card fetching work in production.

## Problem
After fixing the API client error handling (PR #70) and Cloudflare Functions issues (PR #72, #73), Prairie Card still failed with "Prairie Cardの取得に失敗しました" error.

The issue was that usePrairieCard.ts was expecting a MinimalProfile format but the API now returns PrairieProfile directly after our API client changes.

## Solution
- Updated usePrairieCard to handle PrairieProfile response directly
- Fixed validation to check `response.basic.name` instead of `data.name`
- Removed unnecessary MinimalProfile import and conversion

## Test Results
✅ Build passes successfully
✅ TypeScript checks pass

## Related PRs
- #70 - API client error handling fix
- #72 - Cloudflare Functions process.env fix
- #73 - prairie.ts env parameter fix

This should complete the Prairie Card functionality fix.

🤖 Generated with [Claude Code](https://claude.ai/code)