### PR TITLE
fix: TypeScript type-check errors in diagnosis-engine-v3.test.ts

### DIFF
--- a/src/lib/__tests__/diagnosis-engine-v3.test.ts
+++ b/src/lib/__tests__/diagnosis-engine-v3.test.ts
@@ -33,11 +33,12 @@ describe('SimplifiedDiagnosisEngine', () => {
     } as any;
     (DiagnosisCache.getInstance as jest.Mock).mockReturnValue(mockCache);
     
-    // Setup OpenAI mock
+    // Setup OpenAI mock with proper typing
+    const mockCreate = jest.fn();
     mockOpenAI = {
       chat: {
         completions: {
-          create: jest.fn() as any,
+          create: mockCreate,
         },
       },
     } as any;
@@ -157,7 +158,7 @@ describe('SimplifiedDiagnosisEngine', () => {
       };
       
       // Setup mock OpenAI response for all tests by default
-      mockOpenAI.chat.completions.create.mockResolvedValue({
+      (mockOpenAI.chat.completions.create as jest.Mock).mockResolvedValue({
         choices: [{
           message: {
             content: JSON.stringify(mockAIResponse),
@@ -225,7 +226,7 @@ describe('SimplifiedDiagnosisEngine', () => {
         }
       };
       
-      mockOpenAI.chat.completions.create.mockResolvedValue({
+      (mockOpenAI.chat.completions.create as jest.Mock).mockResolvedValue({
         choices: [{
           message: {
             content: JSON.stringify(mockAIResponse),
@@ -281,7 +282,7 @@ describe('SimplifiedDiagnosisEngine', () => {
         text: jest.fn().mockResolvedValue(mockHtml1),
       });
       
-      mockOpenAI.chat.completions.create.mockResolvedValue({
+      (mockOpenAI.chat.completions.create as jest.Mock).mockResolvedValue({
         choices: [{
           message: {
             content: 'Invalid JSON',
@@ -338,8 +339,8 @@ describe('SimplifiedDiagnosisEngine', () => {
       
       expect(result).toBeDefined();
       // Check that HTML was trimmed (verify through AI call)
-      if (mockOpenAI.chat.completions.create.mock.calls.length > 0) {
-        const aiCallContent = mockOpenAI.chat.completions.create.mock.calls[0][0].messages[0].content;
+      if ((mockOpenAI.chat.completions.create as jest.Mock).mock.calls.length > 0) {
+        const aiCallContent = (mockOpenAI.chat.completions.create as jest.Mock).mock.calls[0][0].messages[0].content;
         expect(aiCallContent.length).toBeLessThan(150000); // Reasonable limit for prompt
       }
     });


### PR DESCRIPTION
## 概要
TypeScript strict modeで発生していた型エラーを修正します。

## 問題
`npm run type-check`で以下のエラーが発生:
```
error TS2339: Property 'mockResolvedValue' does not exist on type...
error TS2339: Property 'mock' does not exist on type...
```

## 解決策
OpenAIモックの型キャストを適切に実装:
- `mockOpenAI.chat.completions.create`を`jest.Mock`として明示的にキャスト
- モック関数の初期化を改善

## 変更内容
- 🔧 `beforeEach`でモック関数を適切に初期化
- 🔧 全ての`mockResolvedValue`呼び出しに型キャストを追加
- 🔧 `mock.calls`アクセスに型キャストを追加

## テスト結果
### Before
- ❌ Type-check: 5エラー
- ✅ Tests: 10/10 pass

### After
- ✅ Type-check: エラーなし
- ✅ Tests: 10/10 pass

## チェックリスト
- [x] 型エラーの修正
- [x] テストの実行確認
- [x] type-checkの成功確認
- [x] 既存テストへの影響なし

## 関連
- CIの健全性向上
- TypeScript strict mode準拠