### PR TITLE
test: テストカバレッジ拡張 - Prairie Card & v4エンジン (Issue #75)

### DIFF
--- a/src/hooks/__tests__/usePrairieCard.test.ts
+++ b/src/hooks/__tests__/usePrairieCard.test.ts
@@ -140,4 +140,158 @@ describe('usePrairieCard', () => {
 
     expect(result.current.error).toBeNull();
   });
+
+  it('handles response without basic.name correctly', async () => {
+    const mockDataWithoutName = {
+      basic: {
+        title: 'Developer',
+        company: 'Test Company',
+      },
+      details: {},
+      social: {},
+      custom: {},
+      meta: {},
+    };
+
+    (apiClient.prairie.fetch as jest.Mock).mockResolvedValueOnce(mockDataWithoutName);
+
+    const { result } = renderHook(() => usePrairieCard());
+
+    let fetchedProfile: any;
+    await act(async () => {
+      fetchedProfile = await result.current.fetchProfile('https://example.com/profile');
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.error).toBe('Prairie Cardの取得に失敗しました');
+      expect(result.current.profile).toBeNull();
+      expect(fetchedProfile).toBeNull();
+    });
+  });
+
+  it('handles response without basic field correctly', async () => {
+    const mockDataWithoutBasic = {
+      details: { skills: ['React'] },
+      social: {},
+      custom: {},
+      meta: {},
+    };
+
+    (apiClient.prairie.fetch as jest.Mock).mockResolvedValueOnce(mockDataWithoutBasic);
+
+    const { result } = renderHook(() => usePrairieCard());
+
+    let fetchedProfile: any;
+    await act(async () => {
+      fetchedProfile = await result.current.fetchProfile('https://example.com/profile');
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.error).toBe('Prairie Cardの取得に失敗しました');
+      expect(result.current.profile).toBeNull();
+      expect(fetchedProfile).toBeNull();
+    });
+  });
+
+  it('handles complete profile with all optional fields', async () => {
+    const completeProfile = {
+      basic: {
+        name: '＿・）つかまん',
+        title: 'フルスタックエンジニア',
+        company: 'テック株式会社',
+        bio: 'クラウドネイティブ技術に情熱を注ぐエンジニア',
+        avatar: 'https://example.com/avatar.jpg',
+      },
+      details: {
+        tags: ['cloud', 'native', 'kubernetes'],
+        skills: ['Docker', 'Kubernetes', 'Go', 'TypeScript'],
+        interests: ['DevOps', 'SRE', 'Platform Engineering'],
+        certifications: ['CKA', 'AWS Solutions Architect'],
+        communities: ['CNCF', 'Cloud Native Days'],
+        motto: '継続的改善',
+      },
+      social: {
+        twitter: '@tsukaman',
+        github: 'tsukaman',
+        linkedin: 'tsukaman',
+      },
+      custom: {
+        favoriteTools: ['kubectl', 'terraform'],
+      },
+      meta: {
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-08-30T00:00:00Z',
+        connectedBy: 'QR Code',
+        hashtag: '#CloudNativeDays',
+      },
+    };
+
+    (apiClient.prairie.fetch as jest.Mock).mockResolvedValueOnce(completeProfile);
+
+    const { result } = renderHook(() => usePrairieCard());
+
+    let fetchedProfile: any;
+    await act(async () => {
+      fetchedProfile = await result.current.fetchProfile('https://my.prairie.cards/u/tsukaman');
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.error).toBeNull();
+      expect(result.current.profile).toEqual(completeProfile);
+      expect(fetchedProfile).toEqual(completeProfile);
+    });
+
+    // Verify all fields are preserved
+    expect(result.current.profile?.basic.avatar).toBe('https://example.com/avatar.jpg');
+    expect(result.current.profile?.details.certifications).toEqual(['CKA', 'AWS Solutions Architect']);
+    expect(result.current.profile?.social.github).toBe('tsukaman');
+    expect(result.current.profile?.meta.hashtag).toBe('#CloudNativeDays');
+  });
+
+  it('handles multiple consecutive fetch calls correctly', async () => {
+    const profile1 = {
+      basic: { name: 'User 1', title: 'Dev 1', company: 'Company 1', bio: 'Bio 1' },
+      details: { tags: [], skills: [], interests: [], certifications: [], communities: [] },
+      social: {},
+      custom: {},
+      meta: {},
+    };
+
+    const profile2 = {
+      basic: { name: 'User 2', title: 'Dev 2', company: 'Company 2', bio: 'Bio 2' },
+      details: { tags: [], skills: [], interests: [], certifications: [], communities: [] },
+      social: {},
+      custom: {},
+      meta: {},
+    };
+
+    (apiClient.prairie.fetch as jest.Mock)
+      .mockResolvedValueOnce(profile1)
+      .mockResolvedValueOnce(profile2);
+
+    const { result } = renderHook(() => usePrairieCard());
+
+    // First fetch
+    await act(async () => {
+      await result.current.fetchProfile('https://example.com/profile1');
+    });
+
+    await waitFor(() => {
+      expect(result.current.profile?.basic.name).toBe('User 1');
+    });
+
+    // Second fetch should replace the first profile
+    await act(async () => {
+      await result.current.fetchProfile('https://example.com/profile2');
+    });
+
+    await waitFor(() => {
+      expect(result.current.profile?.basic.name).toBe('User 2');
+    });
+
+    expect(apiClient.prairie.fetch).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/lib/__tests__/diagnosis-engine-v4-openai.test.ts
+++ b/src/lib/__tests__/diagnosis-engine-v4-openai.test.ts
@@ -1,0 +1,220 @@
+import { AstrologicalDiagnosisEngineV4 } from '../diagnosis-engine-v4-openai';
+import OpenAI from 'openai';
+import { PrairieProfile } from '@/types';
+
+// Mock OpenAI
+jest.mock('openai');
+
+describe('AstrologicalDiagnosisEngineV4', () => {
+  let engine: AstrologicalDiagnosisEngineV4;
+  let mockOpenAI: jest.Mocked<OpenAI>;
+  
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    // Reset singleton instance
+    (AstrologicalDiagnosisEngineV4 as any).instance = undefined;
+    
+    // Setup OpenAI mock
+    const mockCreate = jest.fn();
+    mockOpenAI = {
+      chat: {
+        completions: {
+          create: mockCreate,
+        },
+      },
+    } as any;
+    (OpenAI as jest.MockedClass<typeof OpenAI>).mockImplementation(() => mockOpenAI);
+    
+    // Set environment
+    process.env.OPENAI_API_KEY = 'test-api-key';
+  });
+  
+  afterEach(() => {
+    delete process.env.OPENAI_API_KEY;
+  });
+  
+  describe('getInstance', () => {
+    it('returns singleton instance', () => {
+      const instance1 = AstrologicalDiagnosisEngineV4.getInstance();
+      const instance2 = AstrologicalDiagnosisEngineV4.getInstance();
+      expect(instance1).toBe(instance2);
+    });
+  });
+  
+  describe('isConfigured', () => {
+    it('returns true when API key is set', () => {
+      const engine = AstrologicalDiagnosisEngineV4.getInstance();
+      expect(engine.isConfigured()).toBe(true);
+    });
+    
+    it('returns false when API key is not set', () => {
+      delete process.env.OPENAI_API_KEY;
+      const engine = AstrologicalDiagnosisEngineV4.getInstance();
+      expect(engine.isConfigured()).toBe(false);
+    });
+  });
+  
+  describe('generateDuoDiagnosis', () => {
+    const mockProfile1: PrairieProfile = {
+      basic: {
+        name: 'テストユーザー1',
+        title: 'エンジニア',
+        company: 'テック社',
+        bio: 'クラウドネイティブエンジニア',
+      },
+      details: {
+        tags: ['cloud'],
+        skills: ['Kubernetes', 'Docker'],
+        interests: ['DevOps'],
+        certifications: [],
+        communities: [],
+      },
+      social: {},
+      custom: {},
+      meta: {},
+    };
+    
+    const mockProfile2: PrairieProfile = {
+      basic: {
+        name: 'テストユーザー2',
+        title: 'デザイナー',
+        company: 'デザイン社',
+        bio: 'UXデザイナー',
+      },
+      details: {
+        tags: ['design'],
+        skills: ['Figma', 'Sketch'],
+        interests: ['UI/UX'],
+        certifications: [],
+        communities: [],
+      },
+      social: {},
+      custom: {},
+      meta: {},
+    };
+    
+    it('generates diagnosis with OpenAI when configured', async () => {
+      const mockResponse = {
+        astrologicalSign: '♈ 牡羊座',
+        energyFlow: '火のエレメント',
+        cosmicAlignment: '新月のエネルギー',
+        soulConnection: '深い魂の共鳴',
+        techStackCompatibility: {
+          harmony: ['コンテナ技術'],
+          challenges: ['フロントエンド'],
+          opportunities: ['DevOps文化'],
+        },
+        conversationTopics: ['クラウドアーキテクチャ'],
+        compatibility: 92,
+        strengths: ['技術力', '創造性'],
+        opportunities: ['協業の可能性'],
+        luckyItem: 'キーボード',
+        luckyAction: 'ペアプログラミング',
+      };
+      
+      (mockOpenAI.chat.completions.create as jest.Mock).mockResolvedValue({
+        choices: [{
+          message: {
+            content: JSON.stringify(mockResponse),
+          },
+        }],
+      });
+      
+      engine = AstrologicalDiagnosisEngineV4.getInstance();
+      const result = await engine.generateDuoDiagnosis(mockProfile1, mockProfile2);
+      
+      expect(result).toBeDefined();
+      expect(result.type).toBe('占星術的クラウドネイティブ診断');
+      expect(result.astrologicalAnalysis).toEqual(mockResponse);
+      expect(result.compatibility).toBe(92);
+      expect(result.names).toEqual(['テストユーザー1', 'テストユーザー2']);
+      
+      // Verify OpenAI was called
+      expect(mockOpenAI.chat.completions.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'gpt-4o-mini',
+          temperature: 0.9,
+          max_tokens: 2000,
+        })
+      );
+    });
+    
+    it('falls back to rule-based diagnosis when not configured', async () => {
+      delete process.env.OPENAI_API_KEY;
+      engine = AstrologicalDiagnosisEngineV4.getInstance();
+      
+      const result = await engine.generateDuoDiagnosis(mockProfile1, mockProfile2);
+      
+      expect(result).toBeDefined();
+      expect(result.type).toBe('占星術的クラウドネイティブ診断');
+      expect(result.astrologicalAnalysis).toBeDefined();
+      expect(result.astrologicalAnalysis?.astrologicalSign).toMatch(/♈|♉|♊|♋|♌|♍|♎|♏|♐|♑|♒|♓/);
+      
+      // Verify OpenAI was not called
+      expect(mockOpenAI.chat.completions.create).not.toHaveBeenCalled();
+    });
+    
+    it('handles OpenAI API errors gracefully', async () => {
+      (mockOpenAI.chat.completions.create as jest.Mock).mockRejectedValue(
+        new Error('API Error')
+      );
+      
+      engine = AstrologicalDiagnosisEngineV4.getInstance();
+      const result = await engine.generateDuoDiagnosis(mockProfile1, mockProfile2);
+      
+      // Should fall back to rule-based
+      expect(result).toBeDefined();
+      expect(result.type).toBe('占星術的クラウドネイティブ診断');
+      expect(result.astrologicalAnalysis).toBeDefined();
+    });
+    
+    it('handles invalid JSON response from OpenAI', async () => {
+      (mockOpenAI.chat.completions.create as jest.Mock).mockResolvedValue({
+        choices: [{
+          message: {
+            content: 'Invalid JSON',
+          },
+        }],
+      });
+      
+      engine = AstrologicalDiagnosisEngineV4.getInstance();
+      const result = await engine.generateDuoDiagnosis(mockProfile1, mockProfile2);
+      
+      // Should fall back to rule-based
+      expect(result).toBeDefined();
+      expect(result.type).toBe('占星術的クラウドネイティブ診断');
+      expect(result.astrologicalAnalysis).toBeDefined();
+    });
+  });
+  
+  describe('summarizeProfile', () => {
+    it('summarizes profile within token limits', () => {
+      const profile: PrairieProfile = {
+        basic: {
+          name: 'Long Name User',
+          title: 'Very Long Title That Should Be Truncated',
+          company: 'Very Long Company Name That Should Be Truncated As Well',
+          bio: 'A'.repeat(300), // Very long bio
+        },
+        details: {
+          tags: [],
+          skills: Array(20).fill('skill'), // 20 skills
+          interests: Array(10).fill('interest'), // 10 interests
+          certifications: [],
+          communities: [],
+        },
+        social: {},
+        custom: {},
+        meta: {},
+      };
+      
+      engine = AstrologicalDiagnosisEngineV4.getInstance();
+      const summary = (engine as any).summarizeProfile(profile);
+      
+      expect(summary.bio.length).toBeLessThanOrEqual(200);
+      expect(summary.skills.length).toBeLessThanOrEqual(10);
+      expect(summary.interests.length).toBeLessThanOrEqual(5);
+    });
+  });
+});


### PR DESCRIPTION
## 概要
Prairie Card機能とv4診断エンジンのテストカバレッジを大幅に拡張しました。

## 背景
PR #72, #74のレビューで指摘されたテストカバレッジ不足を解消します。

## 変更内容

### 📊 Prairie Cardテスト拡張
**usePrairieCard.test.ts**:
- ✅ レスポンス検証テスト追加
  - basic.nameが存在しない場合
  - basicフィールド自体が存在しない場合
- ✅ 完全なプロファイルテスト
  - 全オプションフィールド含む
  - 実際のユーザーデータ例（つかまんさん）
- ✅ 複数連続フェッチテスト
  - 状態の正しい更新を確認

### 🎯 v4エンジンテスト新規作成
**diagnosis-engine-v4-openai.test.ts**:
- ✅ シングルトンパターンテスト
- ✅ 設定確認テスト（APIキー有無）
- ✅ OpenAI統合テスト
  - 正常系
  - エラーハンドリング
  - フォールバック動作
- ✅ プロファイル要約テスト
  - トークン制限内での要約

## テスト結果
### Before
- usePrairieCard: 5テスト
- v4エンジン: 0テスト

### After
- usePrairieCard: **9テスト** (全pass) ✅
- v4エンジン: **8テスト** (4 pass, 4 期待される失敗)

## 今後の改善
- v4エンジンのtype判定ロジック調整
- Cloudflare Functions用テスト追加
- OpenAIモック用ヘルパー関数作成

## チェックリスト
- [x] Prairie Cardテスト拡張
- [x] v4エンジンテスト作成
- [x] 既存テストへの影響なし
- [x] テスト実行確認

## 関連
- Partially addresses #75
- 関連PR: #72, #74