### PR TITLE
🚨 緊急修正: 診断APIレスポンス構造の不一致によるエラーを解決

### DIFF
--- a/src/hooks/useDiagnosis.ts
+++ b/src/hooks/useDiagnosis.ts
@@ -25,7 +25,11 @@ export function useDiagnosis(): UseDiagnosisReturn {
     setError(null);
     
     try {
-      const result = await apiClient.diagnosis.generate(profiles, mode);
+      const response = await apiClient.diagnosis.generate(profiles, mode);
+      
+      // APIレスポンスから実際の診断結果を取得
+      // レスポンス構造: { result: DiagnosisResult } または DiagnosisResult
+      const result = response.result || response;
       
       if (!result || !result.id) {
         throw new Error('診断の生成に失敗しました');


### PR DESCRIPTION
## 🐛 問題

Cloudflareの本番環境で診断実行時に「診断の生成に失敗しました」エラーが発生していました。

### 再現手順
1. https://cnd2.cloudnativedays.jp にアクセス
2. 2人診断を選択
3. Prairie Card URLを入力（例: https://my.prairie.cards/u/tsukaman）
4. 診断開始をクリック → エラー発生

## 🔍 原因

診断APIのレスポンス構造が変更されていたことが原因でした：

### APIレスポンス構造
```json
{
  "success": true,
  "data": {
    "result": {
      "id": "...",
      "mode": "duo",
      "type": "...",
      // 診断結果データ
    }
  }
}
```

### フロントエンドの期待
```json
{
  "id": "...",
  "mode": "duo",
  "type": "...",
  // 診断結果データ
}
```

## ✅ 修正内容

`useDiagnosis.ts` にフォールバック処理を追加：
```typescript
const response = await apiClient.diagnosis.generate(profiles, mode);
// response.result または response のどちらの形式でも対応
const result = response.result || response;
```

## 🧪 テスト結果

- [x] ローカル環境でのテスト完了
- [x] 両方のレスポンス形式に対応することを確認
- [ ] Cloudflare本番環境でのテスト（デプロイ後）

## 📝 備考

この修正により、APIレスポンス構造が変更されても柔軟に対応できるようになりました。

🤖 Generated with [Claude Code](https://claude.ai/code)