### PR TITLE
fix: Prairie Cardパーサーの不正なデータ混入問題を修正

### DIFF
--- a/functions/utils/prairie-parser.js
+++ b/functions/utils/prairie-parser.js
@@ -312,8 +312,6 @@ function parseFromHTML(html, env) {
                 extractTextByClass(html, 'position') ||
                 extractTextByDataField(html, 'title') ||
                 extractTextByDataField(html, 'role') ||
-                // Look for job titles in text
-                html.match(/>([^<]*(?:Engineer|Developer|Designer|Manager|Lead|Architect|Analyst|Consultant|Specialist|Director)[^<]*)</i)?.[1]?.trim() ||
                 '';
                 
   const company = extractTextByClass(html, 'company') ||
@@ -323,8 +321,6 @@ function parseFromHTML(html, env) {
                   extractTextByDataField(html, 'company') ||
                   extractTextByDataField(html, 'organization') ||
                   metaProfile.company ||
-                  // Look for company patterns
-                  html.match(/>([^<]*(?:株式会社|会社|Inc\.|Inc|Corp\.|Corp|Ltd\.|Ltd|LLC|GmbH)[^<]*)</i)?.[1]?.trim() ||
                   '';
                   
   const bio = extractTextByClass(html, 'bio') ||
@@ -334,7 +330,6 @@ function parseFromHTML(html, env) {
               extractTextByClass(html, 'profile-text') ||
               extractTextByDataField(html, 'bio') ||
               extractTextByDataField(html, 'about') ||
-              html.match(/<p[^>]*>([^<]{20,500})<\/p>/i)?.[1]?.trim() ||
               metaProfile.bio ||
               '';
               
@@ -347,20 +342,8 @@ function parseFromHTML(html, env) {
     ...extractArrayByClass(html, 'technology'),
   ];
   
-  // Add technology keywords found in HTML
-  const techKeywords = [
-    'JavaScript', 'TypeScript', 'Python', 'Go', 'Rust', 'Java', 'C++', 'C#', 'Ruby', 'PHP',
-    'React', 'Vue', 'Angular', 'Next.js', 'Nuxt.js', 'Node.js', 'Express', 'Django', 'Rails',
-    'Docker', 'Kubernetes', 'AWS', 'GCP', 'Azure', 'Terraform', 'Ansible',
-    'Git', 'GitHub', 'GitLab', 'CI/CD', 'DevOps', 'Cloud Native', 'Microservices',
-    'PostgreSQL', 'MySQL', 'MongoDB', 'Redis', 'GraphQL', 'REST API', 'gRPC'
-  ];
-  
-  for (const keyword of techKeywords) {
-    if (html.includes(keyword) && !skills.includes(keyword)) {
-      skills.push(keyword);
-    }
-  }
+  // Note: Removed automatic tech keyword extraction as it was causing false positives
+  // Skills should only come from explicitly marked elements in the HTML
   
   const tags = [
     ...extractArrayByClass(html, 'tag'),


### PR DESCRIPTION
## 問題
Prairie Card解析時に以下の問題が発生していました：
- 診断参加者の会社名にJavaScriptコードなど不適切な内容が表示される
- プロフィールに含まれていない技術キーワード（JavaScript、React、Go等）が診断結果に出現する

## 原因
1. **会社名抽出の正規表現が広すぎる**: HTMLから「株式会社」「Inc」等を含む任意のテキストを取得していた
2. **自己紹介抽出の正規表現が広すぎる**: 任意の`<p>`タグの内容を取得していた  
3. **技術キーワードの自動追加**: HTML全体から技術名を検索して自動追加していた

## 修正内容
- 会社名・職種・自己紹介の広すぎる正規表現を削除
- 技術キーワードの自動追加機能を削除
- 明示的にマークされた要素からのみ情報を抽出するように変更

## テスト
以下のPrairie Cardで正常に動作することを確認してください：
- https://my.prairie.cards/u/tsukaman
- https://my.prairie.cards/u/tananyan29
- https://my.prairie.cards/u/jacopen
- https://my.prairie.cards/u/akane.sakaki
- https://my.prairie.cards/u/umihico

Fixes: Prairie Card解析の精度向上