### PR TITLE
fix: TypeScriptビルドエラー修正

### DIFF
--- a/src/test-utils/prairie-profile-factory.ts
+++ b/src/test-utils/prairie-profile-factory.ts
@@ -133,7 +133,11 @@ export class PrairieProfileFactory {
   static createInvalid(): Partial<PrairieProfile> {
     return {
       details: {
+        tags: [],
         skills: ['React'],
+        interests: [],
+        certifications: [],
+        communities: [],
       },
       social: {},
       custom: {},


### PR DESCRIPTION
## 🐛 問題
Cloudflareデプロイが失敗していました。
`prairie-profile-factory.ts`の`createInvalid`メソッドで必須フィールドが不足していました。

## 🔧 修正内容
- `details`に必須フィールド（tags, interests, certifications, communities）を追加
- 空配列で初期化

## ✅ 確認
- ローカルビルド成功確認済み

これによりCloudflareへのデプロイが成功するはずです。