### PR TITLE
feat: 診断結果の永続化と共有機能を実装

### DIFF
--- a/src/app/duo/page.tsx
+++ b/src/app/duo/page.tsx
@@ -54,12 +54,31 @@ export default function DuoPage() {
         // LocalStorageに保存
         localStorage.setItem(`diagnosis-${result.id}`, JSON.stringify(result));
         
-        // KVにも保存（非同期、エラーは無視）
-        fetch(`/api/results/${result.id}`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(result),
-        }).catch(err => console.log('[Duo] Failed to save to KV:', err));
+        // KVにも保存（非同期、リトライ付き）
+        const saveToKV = async (retries = 3) => {
+          for (let i = 0; i < retries; i++) {
+            try {
+              const response = await fetch(`/api/results/${result.id}`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(result),
+              });
+              if (response.ok) {
+                console.log('[Duo] Successfully saved to KV');
+                return;
+              }
+              console.warn(`[Duo] KV save attempt ${i + 1} failed:`, response.status);
+            } catch (err) {
+              console.warn(`[Duo] KV save attempt ${i + 1} error:`, err);
+            }
+            // Wait before retry (exponential backoff)
+            if (i < retries - 1) {
+              await new Promise(resolve => setTimeout(resolve, Math.pow(2, i) * 1000));
+            }
+          }
+          console.error('[Duo] Failed to save to KV after all retries');
+        };
+        saveToKV();
         
         router.push(`/?result=${result.id}&mode=duo`);
       }

--- a/src/app/duo/page.tsx
+++ b/src/app/duo/page.tsx
@@ -51,7 +51,16 @@ export default function DuoPage() {
     if (profiles[0] && profiles[1]) {
       const result = await generateDiagnosis([profiles[0], profiles[1]], 'duo');
       if (result) {
+        // LocalStorageに保存
         localStorage.setItem(`diagnosis-${result.id}`, JSON.stringify(result));
+        
+        // KVにも保存（非同期、エラーは無視）
+        fetch(`/api/results/${result.id}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(result),
+        }).catch(err => console.log('[Duo] Failed to save to KV:', err));
+        
         router.push(`/?result=${result.id}&mode=duo`);
       }
     }

--- a/src/app/duo/page.tsx
+++ b/src/app/duo/page.tsx
@@ -9,6 +9,7 @@ import { BackgroundEffects } from '@/components/effects/BackgroundEffects';
 import PrairieCardInput from '@/components/prairie/PrairieCardInput';
 import { usePrairieCard } from '@/hooks/usePrairieCard';
 import { useDiagnosis } from '@/hooks/useDiagnosis';
+import { RETRY_CONFIG, calculateBackoffDelay } from '@/lib/constants/retry';
 import type { PrairieProfile } from '@/types';
 
 export default function DuoPage() {
@@ -55,8 +56,8 @@ export default function DuoPage() {
         localStorage.setItem(`diagnosis-${result.id}`, JSON.stringify(result));
         
         // KVにも保存（非同期、リトライ付き）
-        const saveToKV = async (retries = 3) => {
-          for (let i = 0; i < retries; i++) {
+        const saveToKV = async () => {
+          for (let i = 0; i < RETRY_CONFIG.maxRetries; i++) {
             try {
               const response = await fetch(`/api/results/${result.id}`, {
                 method: 'POST',
@@ -72,8 +73,8 @@ export default function DuoPage() {
               console.warn(`[Duo] KV save attempt ${i + 1} error:`, err);
             }
             // Wait before retry (exponential backoff)
-            if (i < retries - 1) {
-              await new Promise(resolve => setTimeout(resolve, Math.pow(2, i) * 1000));
+            if (i < RETRY_CONFIG.maxRetries - 1) {
+              await new Promise(resolve => setTimeout(resolve, calculateBackoffDelay(i)));
             }
           }
           console.error('[Duo] Failed to save to KV after all retries');

--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -51,8 +51,16 @@ export default function GroupPage() {
     if (validProfiles.length >= 3) {
       const result = await generateDiagnosis(validProfiles, 'group');
       if (result) {
-        // Store result in localStorage for now (until deployment is fixed)
+        // LocalStorageに保存
         localStorage.setItem(`diagnosis-${result.id}`, JSON.stringify(result));
+        
+        // KVにも保存（非同期、エラーは無視）
+        fetch(`/api/results/${result.id}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(result),
+        }).catch(err => console.log('[Group] Failed to save to KV:', err));
+        
         // Navigate to home with result in state
         router.push(`/?result=${result.id}&mode=group`);
       }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -60,14 +60,23 @@ export default function Home() {
             }
             throw new Error('Result not found');
           })
-          .then(result => {
+          .then((data: DiagnosisResult) => {
             // 取得した結果をLocalStorageにも保存（キャッシュ）
-            localStorage.setItem(`diagnosis-${resultId}`, JSON.stringify(result));
-            setDiagnosisResult(result);
+            localStorage.setItem(`diagnosis-${resultId}`, JSON.stringify(data));
+            setDiagnosisResult(data);
           })
           .catch(error => {
             console.error("Failed to fetch diagnosis result:", error);
-            // 結果が見つからない場合はエラーメッセージを表示可能
+            // セッションストレージからも確認（フォールバック）
+            const sessionResult = sessionStorage.getItem(`diagnosis-${resultId}`);
+            if (sessionResult) {
+              try {
+                const result = JSON.parse(sessionResult);
+                setDiagnosisResult(result);
+              } catch (parseError) {
+                console.error("Failed to parse session storage result:", parseError);
+              }
+            }
           });
       }
     }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -42,7 +42,7 @@ export default function Home() {
   // 診断結果を読み込む
   useEffect(() => {
     if (resultId) {
-      // LocalStorageから結果を取得
+      // まずLocalStorageから結果を取得
       const storedResult = localStorage.getItem(`diagnosis-${resultId}`);
       if (storedResult) {
         try {
@@ -51,6 +51,24 @@ export default function Home() {
         } catch (error) {
           console.error("Failed to parse diagnosis result:", error);
         }
+      } else {
+        // LocalStorageにない場合はAPIから取得
+        fetch(`/api/results/${resultId}`)
+          .then(response => {
+            if (response.ok) {
+              return response.json();
+            }
+            throw new Error('Result not found');
+          })
+          .then(result => {
+            // 取得した結果をLocalStorageにも保存（キャッシュ）
+            localStorage.setItem(`diagnosis-${resultId}`, JSON.stringify(result));
+            setDiagnosisResult(result);
+          })
+          .catch(error => {
+            console.error("Failed to fetch diagnosis result:", error);
+            // 結果が見つからない場合はエラーメッセージを表示可能
+          });
       }
     }
   }, [resultId]);

--- a/src/lib/constants/retry.ts
+++ b/src/lib/constants/retry.ts
@@ -1,0 +1,17 @@
+/**
+ * リトライ設定の定数
+ */
+export const RETRY_CONFIG = {
+  maxRetries: 3,
+  baseDelay: 1000, // 1秒
+  backoffMultiplier: 2, // 指数バックオフの倍率
+} as const;
+
+/**
+ * 指数バックオフによる待機時間を計算
+ * @param attempt 現在の試行回数（0から開始）
+ * @returns 待機時間（ミリ秒）
+ */
+export function calculateBackoffDelay(attempt: number): number {
+  return RETRY_CONFIG.baseDelay * Math.pow(RETRY_CONFIG.backoffMultiplier, attempt);
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,18 @@
+/**
+ * Fortune grade constants with Japanese meanings
+ * 占い結果のグレード定数
+ */
+export const FORTUNE_GRADES = {
+  DAIKICHI: 'daikichi' as const,  // 大吉 - Great blessing
+  KICHI: 'kichi' as const,         // 吉 - Good fortune
+  CHUKICHI: 'chukichi' as const,   // 中吉 - Middle fortune
+  SHOKICHI: 'shokichi' as const,   // 小吉 - Small fortune
+  SUEKICHI: 'suekichi' as const,   // 末吉 - Future fortune
+  KYO: 'kyo' as const              // 凶 - Misfortune (rarely used)
+} as const;
+
+export type FortuneGrade = typeof FORTUNE_GRADES[keyof typeof FORTUNE_GRADES];
+
 export interface PrairieProfile {
   basic: {
     name: string;
@@ -69,7 +84,7 @@ export interface DiagnosisResult {
   luckyAction?: string;
   // Fortune telling elements (点取り占い)
   fortuneScore?: number; // 0-100点の運勢スコア
-  fortuneGrade?: 'daikichi' | 'kichi' | 'chukichi' | 'shokichi' | 'suekichi' | 'kyo';
+  fortuneGrade?: FortuneGrade; // 運勢グレード (大吉/吉/中吉/小吉/末吉/凶)
   fortuneMessage?: string; // 今日の運勢メッセージ
   luckyColor?: string; // ラッキーカラー
   luckyNumber?: number; // ラッキーナンバー

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -67,6 +67,13 @@ export interface DiagnosisResult {
   shareTag?: string;
   luckyItem?: string;
   luckyAction?: string;
+  // Fortune telling elements (点取り占い)
+  fortuneScore?: number; // 0-100点の運勢スコア
+  fortuneGrade?: 'daikichi' | 'kichi' | 'chukichi' | 'shokichi' | 'suekichi' | 'kyo';
+  fortuneMessage?: string; // 今日の運勢メッセージ
+  luckyColor?: string; // ラッキーカラー
+  luckyNumber?: number; // ラッキーナンバー
+  techFortune?: string; // 技術運（例：「今日はバグが少ない日」）
   // V3 engine metadata
   metadata?: {
     engine?: string;


### PR DESCRIPTION
## 📋 概要
診断結果の共有URLが別ブラウザで機能しない問題を修正し、Cloudflare KVを使用した永続化機能を実装しました。

## 🔧 変更内容

### 1. Cloudflare KVによる永続化
- `functions/api/results/[id].js`: 診断結果の保存/取得APIエンドポイント
- 7日間のTTLで診断結果を保存
- CORS対応で別ドメインからもアクセス可能

### 2. 診断結果保存の改善
- `src/app/duo/page.tsx`: 診断完了時にKVへ並行保存
- `src/app/group/page.tsx`: 同様にKVへ並行保存
- LocalStorageとKVの二重保存でフォールバック対応

### 3. 結果取得ロジックの改善
- `src/app/page.tsx`: LocalStorageになければAPIから取得
- 取得した結果をLocalStorageにキャッシュ

## 🎯 解決した問題
- **Before**: 共有URLを別ブラウザで開くと結果が表示されない
- **After**: どのブラウザ/デバイスからも共有URLで結果を閲覧可能

## 🔍 動作フロー
1. 診断実行 → LocalStorage + KV保存
2. 共有URL生成: `/?result=xxx&mode=duo`
3. 別ブラウザでアクセス:
   - LocalStorageを確認
   - なければAPI経由でKVから取得
   - 取得結果をLocalStorageにキャッシュ

## ✅ テスト結果
- TypeScript型チェック: 成功
- ビルド: 成功

## 📝 注意事項
- 開発環境ではKVが使用できないためLocalStorageのみ動作
- 本番環境（Cloudflare Pages）でKVが有効になる
- 診断結果は7日間保持される

🤖 Generated with [Claude Code](https://claude.ai/code)