### PR TITLE
fix: Lint errors and restore CI blocking

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,15 @@
       "rules": {
         "@typescript-eslint/no-require-imports": "off"
       }
+    },
+    {
+      "files": ["**/__tests__/**/*.ts", "**/__tests__/**/*.tsx", "**/*.test.ts", "**/*.test.tsx"],
+      "rules": {
+        "@typescript-eslint/no-require-imports": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "react-hooks/rules-of-hooks": "off",
+        "react/display-name": "off"
+      }
     }
   ]
 }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,14 +32,12 @@ jobs:
         run: npm test
         env:
           CI: true
-        continue-on-error: true
           
-      - name: Run linting checks (non-blocking)
-        run: npm run lint || true
+      - name: Run linting checks
+        run: npm run lint
         
       - name: Run TypeScript type checking
         run: npm run type-check
-        continue-on-error: true
         
       - name: Create production environment file
         run: |

--- a/src/app/duo/__tests__/page.test.tsx
+++ b/src/app/duo/__tests__/page.test.tsx
@@ -4,6 +4,7 @@ import '@testing-library/jest-dom';
 import DuoPage from '../page';
 import { useRouter } from 'next/navigation';
 import { createLocalStorageMock, createMockPrairieProfile } from '@/test-utils/mocks';
+import type { PrairieProfile, DiagnosisResult } from '@/types';
 
 // Next.js navigationモック
 jest.mock('next/navigation', () => ({
@@ -36,10 +37,10 @@ jest.mock('@/lib/api-client', () => ({
 // コンポーネントモック
 jest.mock('@/components/prairie/PrairieCardInput', () => ({
   __esModule: true,
-  default: ({ onProfileLoaded, disabled }: any) => {
-    const React = require('react');
-    const { apiClient } = require('@/lib/api-client');
-    const [error, setError] = React.useState(null);
+  default: function MockPrairieCardInput({ onProfileLoaded, disabled }: { onProfileLoaded: (profile: PrairieProfile) => void; disabled?: boolean }) {
+    const React = jest.requireActual('react') as typeof import('react');
+    const { apiClient } = jest.requireActual('@/lib/api-client') as { apiClient: { fetchPrairieCard: (url: string) => Promise<PrairieProfile> } };
+    const [error, setError] = React.useState<string | null>(null);
     
     const handleClick = async () => {
       if (disabled) return;
@@ -54,7 +55,7 @@ jest.mock('@/components/prairie/PrairieCardInput', () => ({
           } else if (!result?.success) {
             throw new Error('Failed to fetch profile');
           }
-        } catch (err: any) {
+        } catch (err) {
           // Show error message like the real component
           setError('Prairie Cardの読み込みに失敗しました');
         }
@@ -77,7 +78,7 @@ jest.mock('@/components/prairie/PrairieCardInput', () => ({
 }));
 
 jest.mock('@/components/diagnosis/DiagnosisResult', () => ({
-  DiagnosisResult: ({ result }: any) => (
+  DiagnosisResult: ({ result }: { result: DiagnosisResult }) => (
     <div data-testid="diagnosis-result">
       {result.compatibility}% - {result.summary}
     </div>

--- a/src/app/group/__tests__/page.test.tsx
+++ b/src/app/group/__tests__/page.test.tsx
@@ -4,6 +4,7 @@ import '@testing-library/jest-dom';
 import GroupPage from '../page';
 import { useRouter } from 'next/navigation';
 import { createLocalStorageMock, createMockPrairieProfile } from '@/test-utils/mocks';
+import type { PrairieProfile, DiagnosisResult } from '@/types';
 
 // Next.js navigationモック
 jest.mock('next/navigation', () => ({
@@ -40,10 +41,10 @@ jest.mock('@/lib/api-client', () => ({
 
 // コンポーネントモック
 jest.mock('@/components/prairie/PrairieCardInput', () => {
-  return function MockPrairieCardInput({ onProfileLoaded }: any) {
-    const React = require('react');
-    const { apiClient } = require('@/lib/api-client');
-    const [error, setError] = React.useState(null);
+  return function MockPrairieCardInput({ onProfileLoaded }: { onProfileLoaded: (profile: PrairieProfile) => void }) {
+    const React = jest.requireActual('react') as typeof import('react');
+    const { apiClient } = jest.requireActual('@/lib/api-client') as { apiClient: { prairie: { fetch: { mock?: boolean } } } };
+    const [error, setError] = React.useState<string | null>(null);
     
     const handleClick = async () => {
       setError(null);
@@ -56,7 +57,7 @@ jest.mock('@/components/prairie/PrairieCardInput', () => {
           } else if (!result?.success) {
             throw new Error('Failed to fetch profile');
           }
-        } catch (err: any) {
+        } catch (err) {
           // Show error message like the real component
           setError('Prairie Cardの読み込みに失敗しました');
         }
@@ -78,7 +79,7 @@ jest.mock('@/components/prairie/PrairieCardInput', () => {
 });
 
 jest.mock('@/components/diagnosis/DiagnosisResult', () => ({
-  DiagnosisResult: ({ result }: any) => (
+  DiagnosisResult: ({ result }: { result: DiagnosisResult }) => (
     <div data-testid="diagnosis-result">
       {result.mode} - {result.compatibility}% - {result.summary}
     </div>

--- a/src/lib/api-middleware.ts
+++ b/src/lib/api-middleware.ts
@@ -87,7 +87,7 @@ export function createErrorResponse(
     statusCode = error.statusCode;
     errorMessage = error.message;
     errorCode = error.code;
-    errorMeta = (error as any).meta || {};
+    errorMeta = (error as { meta?: Record<string, unknown> }).meta || {};
   } else if (error instanceof Error) {
     // Keep generic message for security
     errorMessage = 'Internal server error';

--- a/src/lib/diagnosis-engine-v3.ts
+++ b/src/lib/diagnosis-engine-v3.ts
@@ -46,7 +46,7 @@ export class SimplifiedDiagnosisEngine {
    * @internal
    */
   static resetInstance(): void {
-    (SimplifiedDiagnosisEngine as any).instance = undefined;
+    (SimplifiedDiagnosisEngine as unknown as { instance?: SimplifiedDiagnosisEngine }).instance = undefined;
   }
 
   isConfigured(): boolean {
@@ -459,17 +459,18 @@ CloudNative Days Winter 2025を盛り上げる素敵な診断をお願いしま�
 
       return diagnosisResult;
       
-    } catch (error: any) {
+    } catch (error) {
       console.error('[CND²] 診断エラー:', error);
       
       // OpenAI API特有のエラーハンドリング
-      if (error?.status === 429) {
+      const errorWithStatus = error as { status?: number };
+      if (errorWithStatus?.status === 429) {
         throw new Error('AI診断APIのレート制限に達しました。しばらく待ってから再試行してください。');
       }
-      if (error?.status === 401) {
+      if (errorWithStatus?.status === 401) {
         throw new Error('AI診断APIの認証に失敗しました。');
       }
-      if (error?.status === 500 || error?.status === 503) {
+      if (errorWithStatus?.status === 500 || errorWithStatus?.status === 503) {
         throw new Error('AI診断サービスが一時的に利用できません。');
       }
       

--- a/src/lib/prairie-parser.ts
+++ b/src/lib/prairie-parser.ts
@@ -30,7 +30,7 @@ export class PrairieCardParser {
   // テスト用: シングルトンインスタンスをリセット
   static resetInstance(): void {
     if (process.env.NODE_ENV === 'test') {
-      PrairieCardParser.instance = null as any;
+      PrairieCardParser.instance = null as unknown as PrairieCardParser;
     }
   }
 
@@ -157,9 +157,10 @@ export class PrairieCardParser {
       }
 
       return html;
-    } catch (error: any) {
+    } catch (error) {
       // タイムアウトエラー
-      if (error.name === 'AbortError' || error.message === 'AbortError') {
+      const errorAsAny = error as { name?: string; message?: string };
+      if (errorAsAny.name === 'AbortError' || errorAsAny.message === 'AbortError') {
         throw new NetworkError('Prairie Card取得がタイムアウトしました。', { url });
       }
       


### PR DESCRIPTION
## 概要
リントエラーを修正し、CIチェックを再度ブロッキングに戻します。

## 変更内容

### リント設定の改善
- テストファイル用のESLint overridesを追加
  - `@typescript-eslint/no-require-imports`: テストでのrequire使用を許可
  - `@typescript-eslint/no-explicit-any`: テストでのany型を許可
  - `react-hooks/rules-of-hooks`: モック内でのHooks使用を許可
  - `react/display-name`: モックコンポーネントの表示名を不要に

### 本番コードの修正
- `diagnosis-engine-v3.ts`: anyタイプを適切な型に修正
- `prairie-parser.ts`: anyタイプを型アサーションで修正
- `api-middleware.ts`: metaプロパティの型を明確化
- テストファイルでのPrairieProfileとDiagnosisResultのimport追加

### CIワークフローの修正
- `continue-on-error`を削除してCIチェックを再度ブロッキングに
- リントチェックから`|| true`を削除

## 影響
- CIチェックが正常に動作し、リントエラーがある場合はデプロイがブロックされます
- テストファイルでの柔軟な記述が可能になり、開発効率が向上します

## 残作業
将来的に以下の改善を検討：
- テストファイルの型安全性向上
- 未使用変数の整理