### PR TITLE
fix: Fix diagnosis result sharing from KV storage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -43,7 +43,7 @@ export default function Home() {
   useEffect(() => {
     if (resultId) {
       // まずLocalStorageから結果を取得
-      const storedResult = localStorage.getItem(`diagnosis-${resultId}`);
+      const storedResult = localStorage.getItem(`diagnosis-result-${resultId}`);
       if (storedResult) {
         try {
           const result = JSON.parse(storedResult);
@@ -60,15 +60,17 @@ export default function Home() {
             }
             throw new Error('Result not found');
           })
-          .then((data: DiagnosisResult) => {
+          .then((response) => {
+            // APIレスポンスから結果を抽出
+            const result = response.data?.result || response;
             // 取得した結果をLocalStorageにも保存（キャッシュ）
-            localStorage.setItem(`diagnosis-${resultId}`, JSON.stringify(data));
-            setDiagnosisResult(data);
+            localStorage.setItem(`diagnosis-result-${resultId}`, JSON.stringify(result));
+            setDiagnosisResult(result);
           })
           .catch(error => {
             console.error("Failed to fetch diagnosis result:", error);
             // セッションストレージからも確認（フォールバック）
-            const sessionResult = sessionStorage.getItem(`diagnosis-${resultId}`);
+            const sessionResult = sessionStorage.getItem(`diagnosis-result-${resultId}`);
             if (sessionResult) {
               try {
                 const result = JSON.parse(sessionResult);


### PR DESCRIPTION
## 修正内容

診断結果の共有URLが機能していない問題を修正しました。

### 問題
- 共有URL（例: `/?result=xxx&mode=duo`）にアクセスしても結果が表示されない
- KV storageから結果は正しく取得できているが、クライアント側で正しく処理されていない

### 原因
1. APIレスポンスの構造が `{success: true, data: {result: ...}}` だが、クライアントは結果を直接期待していた
2. localStorage/sessionStorageのキーが間違っていた（`diagnosis-` → `diagnosis-result-`）

### 修正
1. APIレスポンスから `data.result` を正しく抽出
2. localStorage/sessionStorageのキーを統一（`diagnosis-result-${resultId}`）

### 確認済み
- KV storage APIは正常に動作（`/api/results/[id]`）
- 結果データは7日間保存される

### テスト
共有URL例: https://138e438c.cnd2-app.pages.dev/?result=eekn3et9jq8mezywg64&mode=duo

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>