### PR TITLE
🚨 緊急修正: 診断結果がローディング画面で止まる不具合を修正

### DIFF
--- a/src/app/duo-v3/page.tsx
+++ b/src/app/duo-v3/page.tsx
@@ -31,7 +31,7 @@ export default function DuoV3Page() {
 
   // 診断結果が返ってきたら遷移
   if (result) {
-    localStorage.setItem(`diagnosis-${result.id}`, JSON.stringify(result));
+    localStorage.setItem(`diagnosis-result-${result.id}`, JSON.stringify(result));
     router.push(`/?result=${result.id}&mode=duo`);
   }
 

--- a/src/app/duo/page.tsx
+++ b/src/app/duo/page.tsx
@@ -103,7 +103,7 @@ export default function DuoPage() {
         const result = await generateDiagnosis([profiles[0], profiles[1]], 'duo');
         if (result) {
           // LocalStorageに保存
-          localStorage.setItem(`diagnosis-${result.id}`, JSON.stringify(result));
+          localStorage.setItem(`diagnosis-result-${result.id}`, JSON.stringify(result));
           
           // KVにも保存（非同期、リトライ付き）
           const saveToKV = async () => {

--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -53,7 +53,7 @@ export default function GroupPage() {
       const result = await generateDiagnosis(validProfiles, 'group');
       if (result) {
         // LocalStorageに保存
-        localStorage.setItem(`diagnosis-${result.id}`, JSON.stringify(result));
+        localStorage.setItem(`diagnosis-result-${result.id}`, JSON.stringify(result));
         
         // KVにも保存（非同期、リトライ付き）
         const saveToKV = async () => {


### PR DESCRIPTION
## 🐛 修正した不具合

診断完了後、「診断結果を読み込み中... 結果ID: xxx」の画面で止まってしまい、結果が表示されない致命的な不具合を修正しました。

## 🔍 原因

localStorage のキーパターンが不一致でした：
- **保存時**: `diagnosis-${result.id}`
- **読込時**: `diagnosis-result-${resultId}`

## ✅ 修正内容

以下のファイルで localStorage キーを統一：
- `src/app/duo/page.tsx:106` → `diagnosis-result-` プレフィックスに変更
- `src/app/group/page.tsx:56` → `diagnosis-result-` プレフィックスに変更
- `src/app/duo-v3/page.tsx:34` → `diagnosis-result-` プレフィックスに変更

## 🧪 テスト結果

- [x] ローカル環境でPlaywrightによる動作確認済み
- [x] 診断結果が正常に表示されることを確認
- [x] Cloudflare環境でも同じ不具合を確認（デプロイ後に解消予定）

## 📸 修正前後の動作

**修正前**: ローディング画面で無限に待機
**修正後**: 診断結果が正常に表示

## 🚀 デプロイ優先度

**緊急度: 🔴 最高**
本番環境で診断機能が実質的に使用不可能な状態のため、即座のデプロイが必要です。

🤖 Generated with [Claude Code](https://claude.ai/code)