### PR TITLE
fix: 診断結果シェア機能のKVストレージ保存/取得を修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,7 +392,37 @@ try {
 
 ## 🔄 最近の重要な変更
 
-### 2025-09-02の変更（最新）
+### 2025-09-01の変更（最新）
+
+#### 緊急対応: Next.js 15.5.0 静的エクスポート互換性問題の完全解決 🚨
+1. **Cloudflare Pages デプロイ失敗の根本原因解決**
+   - **問題**: Next.js 15.5.0 で `output: 'export'` 使用時に動的ルート `[id]` が使用不可
+   - **解決**: すべての動的ルートを削除し、クエリパラメータベースに移行
+   - **影響範囲**: `/result/[id]` → `/duo/results?id=` 形式に完全移行
+
+2. **複数の緊急修正PRによる段階的解決**
+   - **PR #125**: TypeScript コンパイルエラー修正
+     - `DiagnosisResult` 型に不足していたプロパティ追加
+     - `KVNamespace` インターフェースの型定義追加
+   - **PR #127**: Next.js 15.5.0 パラメータ型変更対応
+     - 動的ルートパラメータが `Promise<{id: string}>` 型に変更
+   - **PR #128**: 動的ルート完全削除（最終解決）
+     - `/src/app/api/results/[id]/route.ts` 削除
+     - `/src/app/result/[id]/page.tsx` 削除
+     - Cloudflare Functions でのみ結果取得API提供
+
+3. **Dependabot 依存関係更新 (PR #129)**
+   - **重要な発見**: Zod v4.0.0-beta.2 は OpenAI SDK v5.16.0 と非互換
+   - **解決**: Zod を v3.25.76 に維持（OpenAI の peer dependency 要件）
+   - **更新済み**: Next.js 15.5.2、Sentry 10.8.0、その他開発依存関係
+
+4. **シェアボタンUX改善 (PR #132)**
+   - **問題1**: 「リンクをコピー」ボタンの文字が背景と同色で見えない
+   - **解決**: `text-gray-700` クラスを追加して視認性改善
+   - **問題2**: 開発環境で本番URLが使用される
+   - **解決**: `window.location.origin` で動的URL生成
+
+### 2025-09-02の変更
 
 #### PR #130 - AI診断エンジン有効化と大規模コードクリーンアップ 🎉
 1. **Cloudflare FunctionsでAI診断エンジンを有効化**

--- a/src/app/duo/page.tsx
+++ b/src/app/duo/page.tsx
@@ -68,12 +68,16 @@ export default function DuoPage() {
             // KVストレージにも保存（本番環境のみ、エラーがあっても続行）
             if (isProduction() || process.env.NEXT_PUBLIC_APP_URL) {
               try {
-                await fetch(`/api/results/${result.id}`, {
+                const response = await fetch('/api/results', {
                   method: 'POST',
                   headers: { 'Content-Type': 'application/json' },
                   body: JSON.stringify(result),
                 });
-                logger.info('[Duo] Result saved to KV storage');
+                if (response.ok) {
+                  logger.info('[Duo] Result saved to KV storage');
+                } else {
+                  logger.warn('[Duo] KV storage response not ok:', response.status);
+                }
               } catch (kvError) {
                 logger.warn('[Duo] Failed to save to KV storage:', kvError);
                 // KV保存に失敗してもユーザー体験を妨げない

--- a/src/app/duo/results/page.tsx
+++ b/src/app/duo/results/page.tsx
@@ -45,7 +45,7 @@ export default function ResultsPage() {
       // LocalStorageになければKVストレージから取得
       try {
         // Cloudflare Functionsのエンドポイントを使用
-        const apiUrl = `/api/results/${resultId}`;
+        const apiUrl = `/api/results?id=${resultId}`;
         const response = await fetch(apiUrl);
         if (response.ok) {
           const responseData = await response.json();

--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -61,7 +61,7 @@ export default function GroupPage() {
         const saveToKV = async () => {
           for (let i = 0; i < RETRY_CONFIG.maxRetries; i++) {
             try {
-              const response = await fetch(`/api/results/${result.id}`, {
+              const response = await fetch('/api/results', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(result),

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -173,7 +173,7 @@ export default function Home() {
       // LocalStorageにない場合はAPIから取得
       try {
         console.log("Fetching result from API:", resultId);
-        const response = await fetch(`/api/results/${resultId}`);
+        const response = await fetch(`/api/results?id=${resultId}`);
         
         if (!response.ok) {
           throw new Error(`Result not found: ${response.status}`);


### PR DESCRIPTION
## 🐛 問題

ユーザーから報告された問題：
- シェアされたURL（例: https://cnd2-app.pages.dev/duo/results?id=z7o9n3nb3imf19xjc8）にアクセスしても結果が表示されない
- APIが404エラーを返す

## 🔍 原因

Next.js 15.5.0で動的ルートを削除（PR #128）した後、APIパスの更新が不完全だった：

### 間違っていたパス
- **POST（保存）**: `/api/results/${id}` 
- **GET（取得）**: `/api/results/${id}`

### 正しいパス（Cloudflare Functions）
- **POST（保存）**: `/api/results`
- **GET（取得）**: `/api/results?id=${id}`

## ✅ 修正内容

以下のファイルでAPIパスを修正：

1. **src/app/duo/page.tsx**
   - KV保存時のAPIパスを修正
   - レスポンスステータスのチェックを追加

2. **src/app/duo/results/page.tsx**
   - 結果取得時のAPIパスをクエリパラメータ形式に修正

3. **src/app/group/page.tsx**
   - KV保存時のAPIパスを修正

4. **src/app/page.tsx**
   - ホームページの結果取得APIパスを修正

## 🧪 テスト

- ✅ TypeScriptビルド成功
- ✅ Next.js ビルド成功

## 📝 注意事項

この修正により、Cloudflare Functionsの `/api/results` エンドポイントと正しく通信できるようになり、診断結果のシェア機能が復旧します。

🤖 Generated with [Claude Code](https://claude.ai/code)