### PR TITLE
fix: duo/results画面のUIをDiagnosisResultコンポーネントと統一

### DIFF
--- a/src/app/duo/results/page.tsx
+++ b/src/app/duo/results/page.tsx
@@ -240,23 +240,25 @@ export default function ResultsPage() {
               transition={{ delay: 0.8 }}
               className="mb-8"
             >
-              <div className="flex items-center mb-4">
-                <MessageCircle className="w-5 h-5 text-cyan-400 mr-2" />
-                <h3 className="text-lg font-bold text-cyan-400">おすすめの会話トピック</h3>
-              </div>
-              <div className="space-y-3">
-                {result.conversationStarters.map((topic, index) => (
-                  <motion.div
-                    key={index}
-                    initial={{ opacity: 0, x: -10 }}
-                    animate={{ opacity: 1, x: 0 }}
-                    transition={{ delay: 0.9 + index * 0.1 }}
-                    className="flex items-start"
-                  >
-                    <span className="text-cyan-400 mr-2">•</span>
-                    <p className="text-gray-300">{topic}</p>
-                  </motion.div>
-                ))}
+              <div className="bg-gradient-to-r from-cyan-500/20 to-blue-500/20 rounded-2xl p-6 border border-cyan-500/30">
+                <div className="flex items-center mb-4">
+                  <MessageCircle className="w-6 h-6 text-cyan-400 mr-3" />
+                  <h3 className="text-xl font-bold text-white">💬 おすすめの会話トピック</h3>
+                </div>
+                <div className="space-y-3">
+                  {result.conversationStarters.map((topic, index) => (
+                    <motion.div
+                      key={index}
+                      initial={{ opacity: 0, x: -20 }}
+                      animate={{ opacity: 1, x: 0 }}
+                      transition={{ delay: 0.9 + index * 0.1 }}
+                      className="flex items-center bg-white/5 rounded-lg p-3 hover:bg-white/10 transition-colors"
+                    >
+                      <span className="text-cyan-400 text-lg mr-3">{index + 1}</span>
+                      <span className="text-white/90 flex-1">{topic}</span>
+                    </motion.div>
+                  ))}
+                </div>
               </div>
             </motion.div>
           )}

--- a/src/components/share/ShareButton.tsx
+++ b/src/components/share/ShareButton.tsx
@@ -151,8 +151,8 @@ export default function ShareButton({ resultId, score }: ShareButtonProps) {
                     </>
                   ) : (
                     <>
-                      <Copy className="w-5 h-5 text-gray-700" />
-                      <span className="text-gray-700">リンクをコピー</span>
+                      <Copy className="w-5 h-5 text-gray-900" />
+                      <span className="text-gray-900 font-semibold">リンクをコピー</span>
                     </>
                   )}
                 </motion.button>


### PR DESCRIPTION
## 🐛 問題

ユーザーから以下の問題が報告されました：
1. PR #131で改善した「おすすめの話題トピック」のUIデザインが`duo/results`画面に反映されていない
2. PR #132で修正した「シェアボタンのリンクコピー」の文字色がまだ薄い

## 🔍 原因

- PR #131は`DiagnosisResult.tsx`コンポーネントのみを更新
- `duo/results/page.tsx`は独自のUIを実装しており、更新が漏れていた
- そのため、同じ診断結果でも表示が異なる状態になっていた

## 🔧 修正内容

### 1. 会話トピックUIの改善（`duo/results/page.tsx`）
- ✅ グラデーション背景（cyan→blue）を追加
- ✅ 番号付きリスト（1, 2, 3...）で整理された表示
- ✅ ホバーエフェクト付きの独立したカード形式
- ✅ より大きなアイコン（w-6 h-6）とフォントサイズ（text-xl）

### 2. シェアボタンのテキスト色強化（`ShareButton.tsx`）
- ✅ テキスト色を`text-gray-700`から`text-gray-900`に変更
- ✅ `font-semibold`を追加して文字を太く
- ✅ より高いコントラストで視認性を改善

## 📸 変更前後

### Before（問題のあった表示）
- 会話トピック：シンプルな箇条書き（`•`マーク）
- シェアボタン：薄いグレー（text-gray-700）

### After（修正後）
- 会話トピック：グラデーション背景付きカード、番号付きリスト
- シェアボタン：濃いグレー（text-gray-900）+ 太字

## ✅ テスト

- [x] ビルド成功を確認
- [x] 開発環境での動作確認
- [x] `duo/results`画面でUIが正しく表示されることを確認
- [x] シェアボタンのテキストが視認しやすいことを確認

## 📝 関連PR

- #131: improvement: 会話トピックの表示とプロンプトを改善
- #132: fix: シェアボタンのテキスト視認性とURLドメインの問題を修正

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>