### PR TITLE
fix: JavaScript構文エラーを修正してCloudflareデプロイを復旧

### DIFF
--- a/functions/api/diagnosis-v4-openai.js
+++ b/functions/api/diagnosis-v4-openai.js
@@ -184,7 +184,6 @@ export async function generateAstrologicalDiagnosis(profiles, mode, env) {
       model: isOpenAIUsed ? CONFIG.MODEL : 'none'
     }
   };
-  }
 }
 
 /**


### PR DESCRIPTION
## 概要
Cloudflare Pagesのデプロイが失敗していた問題を修正します。

## 問題
`functions/api/diagnosis-v4-openai.js`に余分な閉じ括弧があり、JavaScript構文エラーが発生していました：
```
functions/api/diagnosis-v4-openai.js:188:0: ERROR: Unexpected "}"
```

## 修正内容
- 187行目の余分な閉じ括弧を削除
- 正しいブロック構造に修正

## 影響範囲
- Cloudflare Functions: diagnosis API
- デプロイパイプライン

## テスト
- [ ] ローカルでビルド確認
- [ ] Cloudflare Pagesデプロイ成功確認

Fixes deployment failure reported in the last message.