### PR TITLE
fix: Phase 8 - リントエラー完全解決

### DIFF
--- a/src/components/ui/__tests__/OptimizedImage.test.tsx
+++ b/src/components/ui/__tests__/OptimizedImage.test.tsx
@@ -100,6 +100,7 @@ jest.mock('next/image', () => ({
 
 // Mock framer-motion
 jest.mock('framer-motion', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { framerMotionMock } = require('../../../test-utils/framer-motion-mock');
   return framerMotionMock;
 });

--- a/src/lib/__tests__/api-client-edge.test.ts
+++ b/src/lib/__tests__/api-client-edge.test.ts
@@ -15,6 +15,7 @@ describe('API Client Edge Cases', () => {
   describe('パス正規化の境界値テスト', () => {
     it('二重スラッシュを正しく処理する', async () => {
       process.env.NEXT_PUBLIC_API_BASE_URL = 'https://test.com';
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { apiClient } = require('../api-client');
       
       (global.fetch as jest.Mock).mockResolvedValueOnce({
@@ -36,6 +37,7 @@ describe('API Client Edge Cases', () => {
       // windowオブジェクトをモック
       (global as unknown as { window?: unknown }).window = {};
       
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { apiClient } = require('../api-client');
       
       (global.fetch as jest.Mock).mockResolvedValueOnce({
@@ -57,6 +59,7 @@ describe('API Client Edge Cases', () => {
 
     it('末尾スラッシュがあるAPI_BASE_URLを正しく処理する', async () => {
       process.env.NEXT_PUBLIC_API_BASE_URL = 'https://test.com/';
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { apiClient } = require('../api-client');
       
       (global.fetch as jest.Mock).mockResolvedValueOnce({
@@ -80,6 +83,7 @@ describe('API Client Edge Cases', () => {
       // windowが存在しない環境をシミュレート
       delete (global as unknown as { window?: unknown }).window;
       
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { apiClient } = require('../api-client');
       
       // SSR環境でのエラー
@@ -100,7 +104,8 @@ describe('API Client Edge Cases', () => {
         jest.resetModules();
         
         process.env.NEXT_PUBLIC_API_BASE_URL = baseUrl;
-        const { apiClient } = require('../api-client');
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { apiClient } = require('../api-client');
         
         (global.fetch as jest.Mock).mockResolvedValueOnce({
           ok: true,
@@ -126,6 +131,7 @@ describe('API Client Edge Cases', () => {
         } 
       };
       
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { apiClient } = require('../api-client');
       
       (global.fetch as jest.Mock).mockResolvedValueOnce({
@@ -153,6 +159,7 @@ describe('API Client Edge Cases', () => {
         } 
       };
       
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { apiClient } = require('../api-client');
       
       (global.fetch as jest.Mock).mockResolvedValueOnce({

--- a/src/lib/__tests__/api-client.test.ts
+++ b/src/lib/__tests__/api-client.test.ts
@@ -26,7 +26,9 @@ describe('API Client', () => {
   describe('Prairie API', () => {
     describe('fetch', () => {
       it('正しいURLでPOSTリクエストを送信する', async () => {
-        const { apiClient } = require('../api-client');
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { apiClient } = require('../api-client');
         const mockResponse = { success: true, data: { name: 'Test User' } };
         (global.fetch as jest.Mock).mockResolvedValueOnce({
           ok: true,
@@ -48,7 +50,9 @@ describe('API Client', () => {
       });
 
       it('HTTPエラーの場合、エラーをスローする', async () => {
-        const { apiClient } = require('../api-client');
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { apiClient } = require('../api-client');
         (global.fetch as jest.Mock).mockResolvedValueOnce({
           ok: false,
           status: 404,
@@ -60,7 +64,9 @@ describe('API Client', () => {
       });
 
       it('ネットワークエラーの場合、デフォルトエラーメッセージを使用する', async () => {
-        const { apiClient } = require('../api-client');
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { apiClient } = require('../api-client');
         (global.fetch as jest.Mock).mockResolvedValueOnce({
           ok: false,
           status: 500,
@@ -81,7 +87,9 @@ describe('API Client', () => {
       ];
 
       it('2人診断のリクエストを正しく送信する', async () => {
-        const { apiClient } = require('../api-client');
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { apiClient } = require('../api-client');
         const mockResponse = { 
           success: true, 
           data: { 
@@ -111,7 +119,9 @@ describe('API Client', () => {
       });
 
       it('グループ診断のリクエストを正しく送信する', async () => {
-        const { apiClient } = require('../api-client');
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { apiClient } = require('../api-client');
         const groupProfiles = [...mockProfiles, { basic: { name: 'User3' } }];
         const mockResponse = { success: true, data: { result: { id: 'group-123' } } };
         
@@ -133,7 +143,9 @@ describe('API Client', () => {
       });
 
       it('デフォルトでduoモードを使用する', async () => {
-        const { apiClient } = require('../api-client');
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { apiClient } = require('../api-client');
         const mockResponse = { success: true };
         (global.fetch as jest.Mock).mockResolvedValueOnce({
           ok: true,
@@ -155,7 +167,9 @@ describe('API Client', () => {
   describe('Results API', () => {
     describe('get', () => {
       it('結果を取得する', async () => {
-        const { apiClient } = require('../api-client');
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { apiClient } = require('../api-client');
         const mockResult = { 
           success: true, 
           data: { 
@@ -181,7 +195,9 @@ describe('API Client', () => {
       });
 
       it('404エラーを処理する', async () => {
-        const { apiClient } = require('../api-client');
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { apiClient } = require('../api-client');
         (global.fetch as jest.Mock).mockResolvedValueOnce({
           ok: false,
           status: 404,
@@ -195,7 +211,9 @@ describe('API Client', () => {
 
     describe('save', () => {
       it('結果を保存する', async () => {
-        const { apiClient } = require('../api-client');
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { apiClient } = require('../api-client');
         const mockResult = { id: 'test-123', compatibility: 85 };
         const mockResponse = { success: true, data: { id: 'test-123' } };
         
@@ -221,7 +239,9 @@ describe('API Client', () => {
 
     describe('delete', () => {
       it('結果を削除する', async () => {
-        const { apiClient } = require('../api-client');
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { apiClient } = require('../api-client');
         const mockResponse = { success: true, message: 'Deleted' };
         
         (global.fetch as jest.Mock).mockResolvedValueOnce({
@@ -246,6 +266,7 @@ describe('API Client', () => {
 
   describe('URL処理', () => {
     it('先頭のスラッシュを削除する', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { apiClient } = require('../api-client');
       (global.fetch as jest.Mock).mockResolvedValueOnce({
         ok: true,
@@ -269,6 +290,7 @@ describe('API Client', () => {
       
       // windowが定義されている状態でモジュールを再読み込み
       jest.resetModules();
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { apiClient } = require('../api-client');
       
       (global.fetch as jest.Mock).mockResolvedValueOnce({
@@ -292,6 +314,7 @@ describe('API Client', () => {
 
   describe('エラーハンドリング', () => {
     it('ネットワークエラーを適切に処理する', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { apiClient } = require('../api-client');
       (global.fetch as jest.Mock).mockRejectedValueOnce(
         new Error('Network error')
@@ -302,6 +325,7 @@ describe('API Client', () => {
     });
 
     it('JSONパースエラーを処理する', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { apiClient } = require('../api-client');
       (global.fetch as jest.Mock).mockResolvedValueOnce({
         ok: true,
@@ -313,6 +337,7 @@ describe('API Client', () => {
     });
 
     it('タイムアウトエラーを処理する', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { apiClient } = require('../api-client');
       (global.fetch as jest.Mock).mockRejectedValueOnce(
         new Error('Request timeout')

--- a/src/lib/__tests__/env.test.ts
+++ b/src/lib/__tests__/env.test.ts
@@ -9,6 +9,7 @@ describe('Environment validation', () => {
     });
 
     it('returns default API configuration', () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { getApiConfig } = require('@/lib/env');
       const config = getApiConfig();
 
@@ -28,6 +29,7 @@ describe('Environment validation', () => {
       // Mock window to simulate client environment
       (global as unknown as { window?: unknown }).window = {};
       
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { getServerConfig } = require('@/lib/env');
       expect(() => getServerConfig()).toThrow('getServerConfig() cannot be called on the client side');
       
@@ -38,6 +40,7 @@ describe('Environment validation', () => {
       // Ensure window is undefined (server environment)
       delete (global as unknown as { window?: unknown }).window;
       
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { getServerConfig } = require('@/lib/env');
       const config = getServerConfig();
 

--- a/src/lib/__tests__/rate-limit.test.ts
+++ b/src/lib/__tests__/rate-limit.test.ts
@@ -182,6 +182,7 @@ describe('Rate Limiting', () => {
   describe('Edge Runtime互換性', () => {
     it('setIntervalを使用しない', () => {
       // Read the actual implementation to verify
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const rateLimit = require('../rate-limit');
       const sourceCode = rateLimit.toString();
       

--- a/src/lib/constants/__tests__/fallback.test.ts
+++ b/src/lib/constants/__tests__/fallback.test.ts
@@ -5,10 +5,11 @@ jest.mock('@/lib/utils/environment', () => ({
 }));
 
 import { isFallbackAllowed, getFallbackScoreRange } from '../fallback';
+import { isDevelopment, getEnvBoolean } from '@/lib/utils/environment';
 
 describe('フォールバック診断制御', () => {
-  const mockIsDevelopment = require('@/lib/utils/environment').isDevelopment;
-  const mockGetEnvBoolean = require('@/lib/utils/environment').getEnvBoolean;
+  const mockIsDevelopment = isDevelopment as jest.MockedFunction<typeof isDevelopment>;
+  const mockGetEnvBoolean = getEnvBoolean as jest.MockedFunction<typeof getEnvBoolean>;
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/src/lib/diagnosis-engine-unified.ts
+++ b/src/lib/diagnosis-engine-unified.ts
@@ -217,7 +217,7 @@ export class UnifiedDiagnosisEngine {
       }
 
       // luckyProjectがある場合は分解（共通関数を使用）
-      let processedResult: Partial<DiagnosisResult> = { ...result };
+      const processedResult: Partial<DiagnosisResult> = { ...result };
       if (result.luckyProject) {
         const { name, description } = parseLuckyProject(result.luckyProject);
         processedResult.luckyProject = name;
@@ -308,7 +308,7 @@ export class UnifiedDiagnosisEngine {
       }
 
       // luckyProjectがある場合は分解（共通関数を使用）
-      let processedResult: Partial<DiagnosisResult> = { ...result };
+      const processedResult: Partial<DiagnosisResult> = { ...result };
       if (result.luckyProject) {
         const { name, description } = parseLuckyProject(result.luckyProject);
         processedResult.luckyProject = name;


### PR DESCRIPTION
## 概要
Phase 8としてリントエラーの完全解決を実施しました。

## 変更内容

### require()インポートエラーの修正（31→0）✅
- テストファイル内の動的require()にESLintディレクティブを追加
  - `api-client.test.ts`: jest.resetModules()と組み合わせた環境変数テスト用
  - `api-client-edge.test.ts`: Edge Runtime互換性テスト用
  - `env.test.ts`: 環境変数設定テスト用
  - `rate-limit.test.ts`: モジュール実装検証用
  - `OptimizedImage.test.tsx`: framer-motionモック用
- `fallback.test.ts`でES6インポート＋型アサーションを使用

### prefer-constエラーの修正（2→0）✅
- `diagnosis-engine-unified.ts`で不要なletをconstに変更
- processedResult変数の再代入がないことを確認

## 結果

### ビルドステータス
```
✅ エラー: 0個（完全解決）
⚠️  警告: 25個（未使用変数の警告のみ）
```

### 警告の内訳
- `@typescript-eslint/no-unused-vars`: 25個
  - 主にテストファイルとプレースホルダー実装での未使用変数
  - ビルドやデプロイには影響なし

## テスト
- `npm run lint`: エラー0、警告25
- `npm run build`: 成功
- `npm test`: 全テストパス

## 今後の改善項目
1. 未使用変数警告の削減（必要に応じて）
2. ESLint設定のFlat Config形式への移行（ESLint 9.0+対応）

🤖 Generated with Claude Code