### PR TITLE
🚨 hotfix: TypeScript mock関数の型エラーを修正

### DIFF
--- a/src/lib/constants/__tests__/fallback.test.ts
+++ b/src/lib/constants/__tests__/fallback.test.ts
@@ -31,7 +31,7 @@ describe('フォールバック診断制御', () => {
     });
 
     it('環境変数が未設定の場合デフォルトでfalseを返す', () => {
-      mockGetEnvBoolean.mockImplementation((key: string, defaultValue: boolean) => defaultValue);
+      mockGetEnvBoolean.mockImplementation((key: string, defaultValue: boolean = false) => defaultValue);
       
       expect(isFallbackAllowed()).toBe(false);
     });


### PR DESCRIPTION
## 🚨 緊急修正

GitHub Actions Deploy to Cloudflare Pages (Production)がTypeScript型エラーで失敗していたため、緊急修正を行いました。

## 問題
```typescript
error TS2345: Argument of type '(key: string, defaultValue: boolean) => boolean' is not assignable to parameter of type '(key: string, defaultValue?: boolean | undefined) => boolean'.
```

`fallback.test.ts`のモック関数で、`getEnvBoolean`の`defaultValue`パラメータの型が不一致でした。

## 修正内容
```typescript
// Before
mockGetEnvBoolean.mockImplementation((key: string, defaultValue: boolean) => defaultValue);

// After  
mockGetEnvBoolean.mockImplementation((key: string, defaultValue: boolean = false) => defaultValue);
```

`defaultValue`パラメータにデフォルト値（`= false`）を追加し、実装と型定義を一致させました。

## 確認
- ✅ `npm run type-check`: エラーなし
- ✅ `npm test`: 全テストパス
- ✅ `npm run build`: ビルド成功

## 影響範囲
- テストファイルのみの修正のため、本番コードへの影響なし

🤖 Generated with Claude Code