### PR TITLE
feat: CNCFラッキープロジェクトを診断結果画面に表示

### DIFF
--- a/src/app/duo/results/page.tsx
+++ b/src/app/duo/results/page.tsx
@@ -346,6 +346,24 @@ export default function ResultsPage() {
               </div>
             )}
           </motion.div>
+          
+          {/* CNCFラッキープロジェクト */}
+          {result.luckyProject && (
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 1.35 }}
+              className="mt-4"
+            >
+              <div className="bg-purple-900/20 rounded-xl p-4 border border-purple-500/30 text-center">
+                <div className="flex items-center justify-center mb-2">
+                  <span className="text-2xl mr-2">🚀</span>
+                  <span className="text-sm text-gray-400">CNCFラッキープロジェクト</span>
+                </div>
+                <p className="text-purple-300 font-bold text-lg">{result.luckyProject}</p>
+              </div>
+            </motion.div>
+          )}
         </motion.div>
 
         {/* アクションボタン */}

--- a/src/components/diagnosis/DiagnosisResult.tsx
+++ b/src/components/diagnosis/DiagnosisResult.tsx
@@ -289,6 +289,31 @@ export function DiagnosisResultComponent({ result, onReset }: DiagnosisResultPro
             </motion.div>
           )}
 
+          {/* CNCFラッキープロジェクト */}
+          {result.luckyProject && (
+            <motion.div
+              initial={{ opacity: 0, scale: 0.9 }}
+              animate={{ opacity: 1, scale: 1 }}
+              transition={{ delay: 1.65 }}
+              className="mb-8 bg-gradient-to-r from-indigo-500/20 to-purple-500/20 rounded-2xl p-5 border border-indigo-400/30"
+            >
+              <div className="text-center">
+                <h3 className="text-lg font-bold text-transparent bg-gradient-to-r from-indigo-400 to-purple-400 bg-clip-text mb-4 flex items-center justify-center">
+                  <span className="mr-2">🚀</span>
+                  CNCFラッキープロジェクト
+                </h3>
+                <div className="text-white/90 font-semibold">
+                  {result.luckyProject}
+                </div>
+                {result.luckyProjectDescription && (
+                  <p className="text-white/70 text-sm mt-2">
+                    {result.luckyProjectDescription}
+                  </p>
+                )}
+              </div>
+            </motion.div>
+          )}
+
           {/* アクションボタン */}
           <motion.div
             initial={{ opacity: 0 }}


### PR DESCRIPTION
## 概要
AIが生成しているが画面に表示されていない「CNCFラッキープロジェクト」情報を、実際の診断結果画面に表示するように修正しました。

## 問題の背景
調査により、以下の未使用フィールドを発見：
- **luckyProject**: 207個のCNCFプロジェクトから選ばれるラッキープロジェクト（**完全に未表示**）
- **luckyProjectDescription**: プロジェクトの説明（型定義のみ）
- **shareTag**: SNS共有用タグ（デバッグモードのみ）
- **modelUsed**: 使用AIモデル名（未表示）

特に`luckyProject`は、AIが時間をかけて生成している重要な情報にも関わらず、ユーザーに表示されていませんでした。

## 変更内容
✅ `src/app/duo/results/page.tsx`
- CNCFラッキープロジェクト専用セクションを追加
- 紫色のグラデーション背景、ロケット🚀アイコン付き

✅ `src/components/diagnosis/DiagnosisResult.tsx`
- 同様のCNCFラッキープロジェクトセクションを追加
- luckyProjectDescriptionの表示にも対応

## テスト結果
- ✅ TypeScript型チェック: パス
- ✅ 関連テスト: 23件パス

## スクリーンショット
新しいCNCFラッキープロジェクトセクションが、ラッキーアイテム・アクションの下に表示されます：
- 紫色のグラデーション背景
- ロケット🚀アイコン
- プロジェクト名と説明を表示

## 今後の改善案
- 他の未使用フィールド（shareTag、modelUsed等）の表示も検討
- fortuneTelling機能の実装完了

🤖 Generated with Claude Code