### PR TITLE
🎨 fix: 診断結果UIをビジネス向けに改善

### DIFF
--- a/src/app/duo/results/page.tsx
+++ b/src/app/duo/results/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
-import { ArrowLeft, Users, Sparkles, Heart, MessageCircle, Target, TrendingUp, Gift, Star } from 'lucide-react';
+import { ArrowLeft, Users, Sparkles, Handshake, MessageCircle, Target, TrendingUp, Gift, Star } from 'lucide-react';
 import Link from 'next/link';
 import { BackgroundEffects } from '@/components/effects/BackgroundEffects';
 import { DiagnosisResult } from '@/types';
@@ -11,6 +11,7 @@ import ShareButton from '@/components/share/ShareButton';
 import { logger } from '@/lib/logger';
 import dynamic from 'next/dynamic';
 import { DiagnosisFullDebug } from '@/components/diagnosis/DiagnosisFullDebug';
+import Image from 'next/image';
 
 const Confetti = dynamic(() => import('react-confetti').then(mod => mod.default), { ssr: false });
 
@@ -136,16 +137,23 @@ export default function ResultsPage() {
                 repeatType: "reverse"
               }}
             >
-              <Heart className="w-16 h-16 text-pink-400" />
+              <Handshake className="w-16 h-16 text-cyan-400" />
             </motion.div>
             <h1 className="text-4xl md:text-5xl font-black mb-3 gradient-text-orange-soft">
               診断結果
             </h1>
+            <p className="text-lg md:text-xl text-gray-300 font-semibold mb-2">
+              CloudNative Days × Connect &apos;n&apos; Discover
+            </p>
             {result.participants && (
-              <p className="text-gray-300 text-lg">
+              <p className="text-gray-300 mb-2">
                 {result.participants[0]?.basic?.name || '1人目'} × {result.participants[1]?.basic?.name || '2人目'}
               </p>
             )}
+            <p className="text-sm">
+              <span className="text-purple-400">Powered by </span>
+              <span className="bg-gradient-to-r from-cyan-400 to-purple-600 bg-clip-text text-transparent font-semibold">Prairie Card</span>
+            </p>
           </div>
         </motion.div>
 
@@ -368,6 +376,28 @@ export default function ResultsPage() {
 
         {/* DEBUG: 全LLMフィールド表示（?debug=trueの時のみ） */}
         {debugMode && <DiagnosisFullDebug result={result} />}
+
+        {/* フッター */}
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 1.5 }}
+          className="flex flex-col items-center gap-4 mt-16 pt-8 border-t border-gray-700/50"
+        >
+          <Image
+            src="/images/trademark@4x.png"
+            alt="CloudNative Days Winter 2025"
+            width={80}
+            height={20}
+            className="opacity-90"
+          />
+          <p className="text-sm md:text-base text-purple-400 font-medium">
+            #CNDxCnD
+          </p>
+          <p className="text-gray-500 text-xs font-medium">
+            © 2025 CloudNative Days Committee
+          </p>
+        </motion.div>
       </div>
     </div>
   );

--- a/src/components/diagnosis/AstrologicalDiagnosisResult.tsx
+++ b/src/components/diagnosis/AstrologicalDiagnosisResult.tsx
@@ -2,9 +2,10 @@
 
 import { motion } from "framer-motion";
 import { DiagnosisResult } from "@/types";
-import { Star, Sparkles, Users, MessageCircle, Zap, Heart, Trophy, Gift, Target } from "lucide-react";
+import { Star, Sparkles, Users, MessageCircle, Zap, Handshake, Trophy, Gift, Target } from "lucide-react";
 import { useState, useEffect } from "react";
 import Confetti from "react-confetti";
+import Image from "next/image";
 
 interface AstrologicalDiagnosisResultProps {
   result: DiagnosisResult;
@@ -71,8 +72,15 @@ export function AstrologicalDiagnosisResult({ result, onReset }: AstrologicalDia
           <h1 className="text-3xl md:text-4xl font-bold text-white mb-2">
             🔮 Cloud Native Days 相性占い 🐳
           </h1>
-          <p className="text-gray-400">
+          <p className="text-lg md:text-xl text-gray-300 font-semibold mb-2">
+            CloudNative Days × Connect &apos;n&apos; Discover
+          </p>
+          <p className="text-gray-400 mb-2">
             占星術 × Cloud Native エンジニアリングで紡ぐ、技術者同士の絆
+          </p>
+          <p className="text-sm">
+            <span className="text-purple-400">Powered by </span>
+            <span className="bg-gradient-to-r from-cyan-400 to-purple-600 bg-clip-text text-transparent font-semibold">Prairie Card</span>
           </p>
         </motion.div>
 
@@ -198,7 +206,7 @@ export function AstrologicalDiagnosisResult({ result, onReset }: AstrologicalDia
               className="glass-effect rounded-2xl p-6"
             >
               <div className="flex items-center mb-4">
-                <Heart className="w-6 h-6 text-pink-400 mr-2" />
+                <Target className="w-6 h-6 text-pink-400 mr-2" />
                 <h3 className="text-lg font-bold text-white">機会</h3>
               </div>
               <ul className="space-y-2">
@@ -297,7 +305,7 @@ export function AstrologicalDiagnosisResult({ result, onReset }: AstrologicalDia
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ delay: 1 }}
-          className="flex justify-center gap-4"
+          className="flex justify-center gap-4 mb-12"
         >
           <button
             onClick={onReset}
@@ -315,6 +323,28 @@ export function AstrologicalDiagnosisResult({ result, onReset }: AstrologicalDia
           >
             結果を共有
           </button>
+        </motion.div>
+
+        {/* フッター */}
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 1.1 }}
+          className="flex flex-col items-center gap-4 pt-8 border-t border-gray-700"
+        >
+          <Image
+            src="/images/trademark@4x.png"
+            alt="CloudNative Days Winter 2025"
+            width={80}
+            height={20}
+            className="opacity-90"
+          />
+          <p className="text-sm md:text-base text-purple-400 font-medium">
+            #CNDxCnD
+          </p>
+          <p className="text-gray-500 text-xs font-medium">
+            © 2025 CloudNative Days Committee
+          </p>
         </motion.div>
       </motion.div>
     </>


### PR DESCRIPTION
## 概要
診断結果ページのUIを、ビジネス向けのイベントに相応しいデザインに改善しました。

## 変更内容

### 1. アイコンの変更
- ❤️ ハートアイコン → 🤝 握手（Handshake）アイコンに変更
- 恋愛関係ではなく、ビジネス・技術交流の相性診断であることを明確化

### 2. CloudNative Daysブランディング要素の追加
診断結果ページに以下のブランディング要素を追加：
- **ヘッダー部分**
  - "CloudNative Days × Connect 'n' Discover" タイトル
  - "Powered by Prairie Card" 表記
- **フッター部分**
  - CloudNative Days Winter 2025 トレードマーク画像
  - #CNDxCnD ハッシュタグ
  - © 2025 CloudNative Days Committee 著作権表示

## 変更箇所
- `/src/app/duo/results/page.tsx` - duo診断結果ページ
- `/src/components/diagnosis/AstrologicalDiagnosisResult.tsx` - 診断結果コンポーネント

## テスト結果
- ✅ ビルド成功
- ✅ テスト通過（パフォーマンステスト1件のみ環境依存でfail）

## スクリーンショット
変更後の診断結果画面には：
- 上部に握手アイコンとブランディングテキスト
- 下部にトレードマークとコピーライト表示

🤖 Generated with [Claude Code](https://claude.ai/code)