### PR TITLE
fix: Prairie Card URLバリデーションでドットを含むユーザー名を許可

### DIFF
--- a/src/lib/validators/__tests__/prairie-url-validator.test.ts
+++ b/src/lib/validators/__tests__/prairie-url-validator.test.ts
@@ -22,6 +22,20 @@ describe('Prairie Card URL Validator', () => {
         expect(result.normalizedUrl).toBe('https://my.prairie.cards/u/akane.sakaki');
       });
 
+      it('複数ドットを含むユーザー名を受け入れる', () => {
+        const result = validatePrairieCardUrl('https://my.prairie.cards/u/user.name.test');
+        expect(result.isValid).toBe(true);
+        expect(result.error).toBeUndefined();
+        expect(result.normalizedUrl).toBe('https://my.prairie.cards/u/user.name.test');
+      });
+
+      it('ドット、アンダースコア、ハイフンの組み合わせを受け入れる', () => {
+        const result = validatePrairieCardUrl('https://my.prairie.cards/u/user.name_123-test');
+        expect(result.isValid).toBe(true);
+        expect(result.error).toBeUndefined();
+        expect(result.normalizedUrl).toBe('https://my.prairie.cards/u/user.name_123-test');
+      });
+
       it('my.prairie.cardsの/cards/{uuid}形式のURLを受け入れる', () => {
         const result = validatePrairieCardUrl('https://my.prairie.cards/cards/20bc9e4a-c2f4-402a-a449-5c59eca48043');
         expect(result.isValid).toBe(true);

--- a/src/lib/validators/__tests__/prairie-url-validator.test.ts
+++ b/src/lib/validators/__tests__/prairie-url-validator.test.ts
@@ -15,6 +15,13 @@ describe('Prairie Card URL Validator', () => {
         expect(result.normalizedUrl).toBe('https://my.prairie.cards/u/tsukaman');
       });
 
+      it('ドットを含むユーザー名も受け入れる', () => {
+        const result = validatePrairieCardUrl('https://my.prairie.cards/u/akane.sakaki');
+        expect(result.isValid).toBe(true);
+        expect(result.error).toBeUndefined();
+        expect(result.normalizedUrl).toBe('https://my.prairie.cards/u/akane.sakaki');
+      });
+
       it('my.prairie.cardsの/cards/{uuid}形式のURLを受け入れる', () => {
         const result = validatePrairieCardUrl('https://my.prairie.cards/cards/20bc9e4a-c2f4-402a-a449-5c59eca48043');
         expect(result.isValid).toBe(true);

--- a/src/lib/validators/prairie-url-validator.ts
+++ b/src/lib/validators/prairie-url-validator.ts
@@ -10,9 +10,9 @@ const ALLOWED_PRAIRIE_HOSTS = new Set([
 ]);
 
 // Prairie CardのURL パターン
-// - /u/{username} 形式
+// - /u/{username} 形式 (ユーザー名にはアルファベット、数字、アンダースコア、ハイフン、ドットを許可)
 // - /cards/{uuid} 形式
-const PRAIRIE_PATH_PATTERN = /^\/(?:u\/[a-zA-Z0-9_-]+|cards\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$/;
+const PRAIRIE_PATH_PATTERN = /^\/(?:u\/[a-zA-Z0-9._-]+|cards\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$/;
 
 export interface PrairieUrlValidationResult {
   isValid: boolean;


### PR DESCRIPTION
## 概要
Prairie Card URLのバリデーションが厳格すぎて、実際の有効なユーザー名が拒否される問題を修正しました。

## 問題
- `https://my.prairie.cards/u/akane.sakaki` のようなドットを含むユーザー名が不正なアドレスとして拒否されていました
- ユーザー名にドット、アンダースコア、ハイフンが含まれる可能性があるのに、ドットが許可されていませんでした

## 変更内容
- ✅ ユーザー名の正規表現パターンを更新
  - 変更前: `/u/[a-zA-Z0-9_-]+`
  - 変更後: `/u/[a-zA-Z0-9._-]+`
- ✅ ドットを含むユーザー名のテストケースを追加

## テスト
```bash
npm test -- src/lib/validators/__tests__/prairie-url-validator.test.ts
```

全22個のテストが成功しています。

## 動作確認
以下のURLパターンが正しく検証されるようになりました：
- ✅ `https://my.prairie.cards/u/akane.sakaki` (ドット)
- ✅ `https://my.prairie.cards/u/user_name` (アンダースコア)
- ✅ `https://my.prairie.cards/u/user-name` (ハイフン)
- ✅ `https://my.prairie.cards/u/user.name_123-test` (組み合わせ)

🤖 Generated with [Claude Code](https://claude.ai/code)