### PR TITLE
fix: 診断結果で5つの分析フィールドが表示されない問題を修正 🔧

### DIFF
--- a/functions/api/diagnosis-v4-openai.js
+++ b/functions/api/diagnosis-v4-openai.js
@@ -472,8 +472,13 @@ ${JSON.stringify(summary2, null, 2)}`;
       luckyProject: luckyProject.name,
       luckyProjectDescription: luckyProject.description,
       luckyProjectUrl: luckyProject.url,
+      // 全5つの分析フィールドを含める
+      fiveElementsAnalysis: analysis?.fiveElementsAnalysis || '',
       astrologicalAnalysis: analysis?.astrologicalAnalysis || '',
-      techStackCompatibility: analysis?.techStackCompatibility || '',
+      numerologyAnalysis: analysis?.numerologyAnalysis || '',
+      energyFieldAnalysis: analysis?.energyFieldAnalysis || '',
+      technicalSynergy: analysis?.technicalSynergy || '',
+      techStackCompatibility: analysis?.techStackCompatibility || analysis?.technicalSynergy || '', // 互換性のため
       strengths: [],
       opportunities: [],
       advice: '',


### PR DESCRIPTION
## 🐛 問題

PR #194で追加した5つの分析フィールドがUIに表示されていない問題を修正しました。

### 調査結果
PlaywrightでAPIレスポンスを確認したところ：
- ✅ `astrologicalAnalysis` は存在する
- ❌ `fiveElementsAnalysis` は存在しない  
- ❌ `numerologyAnalysis` は存在しない
- ❌ `energyFieldAnalysis` は存在しない
- ❌ `technicalSynergy` は存在しない

## 🔧 修正内容

`functions/api/diagnosis-v4-openai.js` のレスポンス構築部分で、全5つの分析フィールドを含めるように修正：

```javascript
// Before: 2つの分析フィールドのみ
astrologicalAnalysis: analysis?.astrologicalAnalysis || '',
techStackCompatibility: analysis?.techStackCompatibility || '',

// After: 全5つの分析フィールドを含める
fiveElementsAnalysis: analysis?.fiveElementsAnalysis || '',
astrologicalAnalysis: analysis?.astrologicalAnalysis || '',
numerologyAnalysis: analysis?.numerologyAnalysis || '',
energyFieldAnalysis: analysis?.energyFieldAnalysis || '',
technicalSynergy: analysis?.technicalSynergy || '',
techStackCompatibility: analysis?.techStackCompatibility || analysis?.technicalSynergy || '',
```

## 🎯 影響

これにより、LLMが生成した以下の分析がすべてユーザーに表示されるようになります：
- **五行思想分析** - 木火土金水のエレメントバランス分析
- **占星術分析** - 星座と惑星の配置から見る相性
- **数秘術分析** - 誕生数と運命数から見る関係性
- **エネルギーフィールド分析** - オーラとチャクラの共鳴
- **技術的シナジー分析** - 技術スタックの補完性

トークンを消費して生成したコンテンツが最大限活用されるようになります。

## ✅ テスト方法

1. https://cnd2-app.pages.dev/duo/ で診断を実行
2. 診断結果画面で5つの分析セクションすべてが表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)