### PR TITLE
🚨 fix: TypeScript型エラーを修正してCloudflare Pagesデプロイを復旧

### DIFF
--- a/src/lib/storage/__tests__/storage-factory.test.ts
+++ b/src/lib/storage/__tests__/storage-factory.test.ts
@@ -8,28 +8,18 @@ import type { DiagnosisResult } from '@/types';
 // モックデータ
 const mockDiagnosisResult: DiagnosisResult = {
   id: 'test-id-123',
-  type: 'standard' as const,
-  score: 85,
+  mode: 'duo',
+  type: 'standard',
+  compatibility: 85,
   aiPowered: true,
   createdAt: new Date().toISOString(),
   summary: 'Test summary',
   strengths: ['strength1'],
   opportunities: ['opportunity1'],
   advice: 'Test advice',
-  fortune: {
-    luckyItem: 'Test item',
-    luckyAction: 'Test action'
-  },
-  members: [
-    {
-      name: 'Test User',
-      profile: {
-        name: 'Test User',
-        bio: 'Test bio',
-        interests: ['test']
-      }
-    }
-  ]
+  luckyItem: 'Test item',
+  luckyAction: 'Test action',
+  participants: []
 };
 
 // LocalStorage モック
@@ -69,7 +59,7 @@ describe('StorageFactory', () => {
 
   describe('開発環境', () => {
     beforeEach(() => {
-      process.env.NODE_ENV = 'development';
+      (process.env as any).NODE_ENV = 'development';
     });
 
     it('LocalStorageImplを返すべき', () => {
@@ -153,7 +143,7 @@ describe('StorageFactory', () => {
 
   describe('本番環境（クライアントサイド）', () => {
     beforeEach(() => {
-      process.env.NODE_ENV = 'production';
+      (process.env as any).NODE_ENV = 'production';
       // windowが定義されている場合はクライアントサイド
     });
 
@@ -225,7 +215,7 @@ describe('StorageFactory', () => {
     const originalWindow = global.window;
     
     beforeEach(() => {
-      process.env.NODE_ENV = 'production';
+      (process.env as any).NODE_ENV = 'production';
       // windowをundefinedにしてサーバーサイドをシミュレート
       // @ts-ignore
       delete global.window;
@@ -264,7 +254,7 @@ describe('StorageFactory', () => {
 
   describe('シングルトンパターン', () => {
     it('同じインスタンスを返すべき', () => {
-      process.env.NODE_ENV = 'development';
+      (process.env as any).NODE_ENV = 'development';
       
       const storage1 = StorageFactory.getStorage();
       const storage2 = StorageFactory.getStorage();
@@ -273,7 +263,7 @@ describe('StorageFactory', () => {
     });
 
     it('reset後は新しいインスタンスを返すべき', () => {
-      process.env.NODE_ENV = 'development';
+      (process.env as any).NODE_ENV = 'development';
       
       const storage1 = StorageFactory.getStorage();
       StorageFactory.reset();
@@ -311,7 +301,7 @@ describe('StorageFactory', () => {
     });
 
     it('ネットワークエラーを適切に処理すべき', async () => {
-      process.env.NODE_ENV = 'production';
+      (process.env as any).NODE_ENV = 'production';
       StorageFactory.reset();
       
       const storage = StorageFactory.getStorage();
@@ -324,7 +314,7 @@ describe('StorageFactory', () => {
     });
 
     it('HTTPエラーを適切に処理すべき', async () => {
-      process.env.NODE_ENV = 'production';
+      (process.env as any).NODE_ENV = 'production';
       StorageFactory.reset();
       
       const storage = StorageFactory.getStorage();

--- a/src/lib/utils/__tests__/kv-storage.test.ts
+++ b/src/lib/utils/__tests__/kv-storage.test.ts
@@ -33,19 +33,18 @@ Object.defineProperty(window, 'localStorage', {
 describe('kv-storage', () => {
   const mockResult: DiagnosisResult = {
     id: 'test-123',
-    type: 'standard' as const,
-    score: 85,
+    mode: 'duo',
+    type: 'standard',
+    compatibility: 85,
     summary: 'Test summary',
     strengths: ['Test strength'],
     opportunities: ['Test opportunity'],
     advice: 'Test advice',
-    members: [],
+    participants: [],
     createdAt: new Date().toISOString(),
     aiPowered: true,
-    fortune: {
-      luckyItem: 'Test item',
-      luckyAction: 'Test action'
-    },
+    luckyItem: 'Test item',
+    luckyAction: 'Test action'
   };
 
   // Mock storage implementation


### PR DESCRIPTION
## 🔥 緊急修正

PR #202のマージ後、Cloudflare Pages本番デプロイが失敗していました。
TypeScript型チェックエラーが原因でした。

## 📋 エラー内容

```
error TS2353: Object literal may only specify known properties, and 'fortune' does not exist in type 'DiagnosisResult'.
error TS2540: Cannot assign to 'NODE_ENV' because it is a read-only property.
```

## 🔧 修正内容

### 1. DiagnosisResult型のモックデータ修正
**storage-factory.test.ts & kv-storage.test.ts:**
- `fortune` オブジェクト → `luckyItem`/`luckyAction` 直接プロパティ
- `members` → `participants`
- `score` → `compatibility`
- `type: 'standard' as const` → `type: 'standard'`
- `mode: 'duo'` を追加（必須フィールド）

### 2. process.env.NODE_ENV代入エラー修正
**storage-factory.test.ts:**
- `process.env.NODE_ENV = value` 
- → `(process.env as any).NODE_ENV = value`
- TypeScriptのreadonly制約を回避

## ✅ 検証結果

```bash
npm run type-check  # ✅ パス
npm test            # ✅ パス
```

## 🚀 デプロイ状態

- この修正により、Cloudflare Pages本番デプロイが正常に動作します
- CIパイプラインも全てパスすることを確認済み

## 📝 関連PR
- #202 - KV storage最適化（この変更が原因でデプロイエラーが発生）

## レビューポイント
1. DiagnosisResult型の使用が正しいか
2. process.env操作の方法が適切か