### PR TITLE
🚨 Emergency Fix 2: TypeScript版Prairie Card UUID validatorも大文字対応

### DIFF
--- a/src/lib/validators/prairie-url-validator.ts
+++ b/src/lib/validators/prairie-url-validator.ts
@@ -11,8 +11,8 @@ const ALLOWED_PRAIRIE_HOSTS = new Set([
 
 // Prairie CardのURL パターン
 // - /u/{username} 形式 (ユーザー名にはアルファベット、数字、アンダースコア、ハイフン、ドットを許可)
-// - /cards/{uuid} 形式
-const PRAIRIE_PATH_PATTERN = /^\/(?:u\/[a-zA-Z0-9._-]+|cards\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$/;
+// - /cards/{uuid} 形式 (UUIDは大文字小文字両方を許可)
+const PRAIRIE_PATH_PATTERN = /^\/(?:u\/[a-zA-Z0-9._-]+|cards\/[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12})$/;
 
 export interface PrairieUrlValidationResult {
   isValid: boolean;


### PR DESCRIPTION
## 🚨 追加の緊急修正

PR #205の修正が不完全でした。TypeScript版のバリデーターにも同じ問題が存在していました。

## 問題
- `src/lib/validators/prairie-url-validator.ts` でもUUID部分が小文字のみ `[a-f0-9]` を許可
- これがフロントエンドのバリデーションで使用されている
- PR #205では`prairie-parser.js`のみ修正したため、まだ500エラーが発生

## 修正内容
```typescript
// Before
const PRAIRIE_PATH_PATTERN = /^\/(?:u\/[a-zA-Z0-9._-]+|cards\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$/;

// After
const PRAIRIE_PATH_PATTERN = /^\/(?:u\/[a-zA-Z0-9._-]+|cards\/[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12})$/;
```

## テスト
- ✅ prairie-url-validator.test.ts: 44/44 テストパス

## 影響度
**CRITICAL** - 本番環境でPrairie Cardが完全に機能しない

## 関連PR
- #205 - 最初の修正（prairie-parser.jsのみ）

🤖 Generated with [Claude Code](https://claude.ai/code)