### PR TITLE
🚨 Emergency Fix 3: getCorsHeaders重複定義によるデプロイ失敗を修正

### DIFF
--- a/functions/api/results.js
+++ b/functions/api/results.js
@@ -192,19 +192,3 @@ export async function onRequestOptions({ request }) {
   });
 }
 
-function getCorsHeaders(requestOrigin) {
-  const allowedOrigins = [
-    'https://cnd2-app.pages.dev',
-    'https://cnd2.cloudnativedays.jp',
-    'http://localhost:3000',
-  ];
-  
-  const origin = allowedOrigins.includes(requestOrigin) ? requestOrigin : null;
-  
-  return {
-    'Access-Control-Allow-Origin': origin,
-    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type',
-    'Access-Control-Max-Age': '86400',
-  };
-}


### PR DESCRIPTION
## 🚨 緊急修正

Cloudflare Pagesのデプロイが失敗している問題を修正。

## エラー内容
```
✘ [ERROR] The symbol "getCorsHeaders" has already been declared
    functions/api/results.js:195:9
```

## 原因
`functions/api/results.js`で：
1. 2行目: `import { getCorsHeaders } from '../utils/response.js';`でインポート
2. 195行目: `function getCorsHeaders(requestOrigin)` で再定義

## 修正
195-210行目のローカル定義を削除（すでにインポートされているため不要）

## 影響度
**CRITICAL** - 本番デプロイが完全にブロックされている

## 関連PR
- #205, #206 - Prairie Card UUID修正がデプロイできない原因

🤖 Generated with [Claude Code](https://claude.ai/code)