### PR TITLE
🚨 Emergency Fix 5: Cloudflare Workerでprocess未定義エラー

### DIFF
--- a/functions/utils/prairie-parser.js
+++ b/functions/utils/prairie-parser.js
@@ -346,9 +346,8 @@ function extractProfileContentBlocks(html) {
     const blockHtml = match[0];
     
     // Debug: Log the actual HTML block structure
-    if (process.env.DEBUG_MODE === 'true') {
-      console.log('[Prairie Parser] ProfileContent block HTML:', blockHtml.substring(0, 500));
-    }
+    // Note: process is not available in Cloudflare Workers
+    // Use debug logger instead if needed
     
     // Extract title - Prairie Card uses nested structure
     // Try multiple patterns to handle different HTML structures


### PR DESCRIPTION
## 🚨 緊急修正

Prairie Card取得でprocess未定義エラーが発生する問題を修正。

## エラー内容
```
ReferenceError: process is not defined
at extractProfileContentBlocks (functionsWorker-0.058406415251937016.js:2170:5)
```

## 原因
`prairie-parser.js`の349行目で`process.env.DEBUG_MODE`を参照していたが、Cloudflare WorkerはNode.js環境ではないため`process`オブジェクトが存在しない。

## 修正内容
```javascript
// Before
if (process.env.DEBUG_MODE === 'true') {
  console.log('[Prairie Parser] ProfileContent block HTML:', blockHtml.substring(0, 500));
}

// After  
// Note: process is not available in Cloudflare Workers
// Use debug logger instead if needed
```

## テスト
- ✅ prairie-parser.test.js: 28/28テストパス

## 影響度
**CRITICAL** - Prairie Card取得が完全に失敗

## 関連PR
- #209 - 前回のWorkerエラー修正

🤖 Generated with [Claude Code](https://claude.ai/code)