### PR TITLE
🚨 fix: OpenRouter AI Gateway URLパスを修正

### DIFF
--- a/functions/api/diagnosis-v4-openai.js
+++ b/functions/api/diagnosis-v4-openai.js
@@ -473,6 +473,18 @@ ${JSON.stringify(summary2, null, 2)}`;
       throw new Error(`${errorMessage} (Status: ${response.status})`);
     }
     
+    // レスポンスのContent-Typeをチェック
+    const contentType = response.headers.get('content-type');
+    if (!contentType || !contentType.includes('application/json')) {
+      const text = await response.text();
+      // HTMLエラーページが返された場合の処理
+      if (text.includes('<!DOCTYPE') || text.includes('<html')) {
+        console.error('[V4-OpenAI Engine] Received HTML error page instead of JSON');
+        throw new Error('API returned HTML error page - check API endpoint configuration');
+      }
+      throw new Error(`Unexpected response format: ${contentType}`);
+    }
+    
     const data = await response.json();
     
     // JSON解析エラーハンドリング

--- a/functions/utils/__tests__/openai-proxy.test.js
+++ b/functions/utils/__tests__/openai-proxy.test.js
@@ -70,7 +70,7 @@ describe('callOpenAIWithProxy', () => {
       });
 
       expect(global.fetch).toHaveBeenCalledWith(
-        'https://gateway.ai.cloudflare.com/v1/account123/gateway123/openrouter',
+        'https://gateway.ai.cloudflare.com/v1/account123/gateway123/openrouter/api/v1/chat/completions',
         expect.objectContaining({
           method: 'POST',
           headers: expect.objectContaining({

--- a/functions/utils/openai-proxy.js
+++ b/functions/utils/openai-proxy.js
@@ -61,11 +61,14 @@ export async function callOpenAIWithProxy({ apiKey, body, env, debugLogger }) {
   if (env?.OPENROUTER_API_KEY && env.OPENROUTER_API_KEY.startsWith('sk-or-v1-')) {
     // AI Gateway経由でOpenRouterを使用（キャッシング・分析のメリットあり）
     if (env?.CLOUDFLARE_ACCOUNT_ID && env?.CLOUDFLARE_GATEWAY_ID) {
-      const gatewayUrl = `https://gateway.ai.cloudflare.com/v1/${env.CLOUDFLARE_ACCOUNT_ID}/${env.CLOUDFLARE_GATEWAY_ID}/openrouter`;
+      // OpenRouter用のAI Gateway URLを構築
+      // 注意: OpenRouterのエンドポイントは /api/v1/chat/completions
+      const gatewayUrl = `https://gateway.ai.cloudflare.com/v1/${env.CLOUDFLARE_ACCOUNT_ID}/${env.CLOUDFLARE_GATEWAY_ID}/openrouter/api/v1/chat/completions`;
       
       debugLogger?.log('Using OpenRouter via AI Gateway (region restriction bypass):', {
         accountId: env.CLOUDFLARE_ACCOUNT_ID.substring(0, 8) + '...',
-        gatewayId: env.CLOUDFLARE_GATEWAY_ID
+        gatewayId: env.CLOUDFLARE_GATEWAY_ID,
+        url: gatewayUrl.replace(env.OPENROUTER_API_KEY, '[REDACTED]')
       });
       
       // OpenRouterではモデル名にプロバイダーのプレフィックスが必要


### PR DESCRIPTION
## 概要
OpenRouter APIからHTMLエラーページが返される問題を修正しました。

## 問題
- AI Gateway経由でOpenRouterを使用する際、URLパスが不正でした
- `/openrouter` で終わっていたため、OpenRouterが "The model 'api/v1' is not available" エラーを返していました

## 修正内容
1. **AI Gateway URLパスの修正**
   - 変更前: `/openrouter`
   - 変更後: `/openrouter/api/v1/chat/completions`

2. **エラーハンドリングの改善**
   - レスポンスのContent-Typeチェックを追加
   - HTMLエラーページが返された場合の適切なエラーメッセージ

## テスト
- ✅ 全てのユニットテストがパス (18/18)
- ✅ ビルド成功

## 関連Issue
- PR #217 のフォローアップ修正

🤖 Generated with [Claude Code](https://claude.ai/code)