### PR TITLE
fix: 共有URLで相性スコアが0%表示される問題を修正

### DIFF
--- a/src/app/duo/results/page.tsx
+++ b/src/app/duo/results/page.tsx
@@ -60,7 +60,8 @@ export default function ResultsPage() {
         if (response.ok) {
           const responseData = await response.json();
           // Cloudflare Functionsのレスポンス形式に対応
-          const data = responseData.result || responseData;
+          // APIレスポンスは { success: true, data: { result: {...} } } の形式
+          const data = responseData.data?.result || responseData.result || responseData;
           setResult(data);
           // LocalStorageにも保存
           localStorage.setItem(`diagnosis-result-${resultId}`, JSON.stringify(data));


### PR DESCRIPTION
## 問題
共有URLにアクセスした際、APIから正しくデータが取得できているにも関わらず、相性スコアが0%と表示される問題がありました。

例: https://cnd2-app.pages.dev/duo/results?id=3cmhm6r10h6mf7m0f3f

## 原因
APIレスポンスの構造が `{ success: true, data: { result: {...} } }` の形式なのに対し、コンポーネントが `responseData.result` を参照していたため、正しくデータを取得できていませんでした。

## 修正内容
`responseData.data?.result` を優先的に参照するように修正しました。これにより、APIの正しいレスポンス構造に対応できるようになります。

## 確認方法
1. 診断を実行して結果を取得
2. 共有URLを別のブラウザ/シークレットモードで開く
3. 相性スコアが正しく表示されることを確認

## 関連PR
- #223: KVストレージのデータ構造正規化（この問題の根本原因の一部を修正）