### PR TITLE
fix: ランディングページのテキスト改善

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -414,7 +414,7 @@ export default function Home() {
         >
           <p className="text-xs text-gray-500">
             ※ 診断を開始することで、Prairie Card の公開プロフィール情報の
-            読み取りと分析に同意したものとみなされます
+            読み取りと分析に同意したことになります
           </p>
         </motion.div>
 

--- a/src/components/landing/AppDescription.tsx
+++ b/src/components/landing/AppDescription.tsx
@@ -32,11 +32,14 @@ export function AppDescription() {
             <Sparkles className="w-6 h-6 text-yellow-400" />
           </h2>
           
+          <p className="text-gray-300 leading-relaxed mb-4">
+            CND²は、CloudNative Days参加者同士の「つながり」と「発見」をサポートします！
+          </p>
+          
           <p className="text-gray-300 leading-relaxed">
-            Prairie Card を AI が分析して、
-            CloudNative Days 参加者同士の相性を診断。
-            技術の共通点から意外な発見まで、
-            新しい出会いのきっかけを作ります！
+            Prairie Card のプロフィール情報をもとに、AIが2人の相性を楽しく分析。
+            技術の話題から意外な共通点まで、
+            新しい出会いのきっかけを見つけましょう！
           </p>
         </motion.div>
       </div>

--- a/src/components/landing/AppDescription.tsx
+++ b/src/components/landing/AppDescription.tsx
@@ -32,16 +32,11 @@ export function AppDescription() {
             <Sparkles className="w-6 h-6 text-yellow-400" />
           </h2>
           
-          <p className="text-gray-300 leading-relaxed mb-4">
-            CND²（シーエヌディースクエア）は、CloudNative Days の参加者同士の
-            「つながり」と「発見」をサポートする相性診断アプリです。
-          </p>
-          
           <p className="text-gray-300 leading-relaxed">
-            Prairie Card のプロフィール情報をもとに、
-            AI が2人の相性を楽しく分析。
-            技術の話題から意外な共通点まで、
-            新しい出会いのきっかけを見つけましょう！
+            Prairie Card を AI が分析して、
+            CloudNative Days 参加者同士の相性を診断。
+            技術の共通点から意外な発見まで、
+            新しい出会いのきっかけを作ります！
           </p>
         </motion.div>
       </div>

--- a/src/components/landing/AppDescription.tsx
+++ b/src/components/landing/AppDescription.tsx
@@ -81,11 +81,11 @@ export function AppDescription() {
               <ol className="space-y-3 text-gray-300">
                 <li className="flex gap-3">
                   <span className="text-cyan-400 font-bold">1.</span>
-                  <span>「Let\'s C\'n\'D!」をタップ</span>
+                  <span>「Let's C'n'D!」をクリック</span>
                 </li>
                 <li className="flex gap-3">
                   <span className="text-cyan-400 font-bold">2.</span>
-                  <span>2人分の Prairie Card URL を入力（QRコード読み取りもOK！）</span>
+                  <span>2人分の Prairie Card URL を入力（QRコード読み取り・AndroidはNFCもOK！）</span>
                 </li>
                 <li className="flex gap-3">
                   <span className="text-cyan-400 font-bold">3.</span>


### PR DESCRIPTION
## 概要
ランディングページの日本語表現とユーザビリティを改善しました。

## 変更内容

### 📝 「かんたん3ステップ」の改善
- エスケープ文字を削除（`Let\'s` → `Let's`）
- デバイス中立な表現に変更（「タップ」→「クリック」）
- NFC読み取り対応を明記（「QRコード読み取り・AndroidはNFCもOK！」）

### 🎯 同意文の自然な日本語表現
- 「同意したものとみなされます」→「同意したことになります」
- より親しみやすく自然な表現に改善

### ✨ ウェルカムメッセージの最適化
- 冗長な説明（読み方など）を削除
- CND²のコアコンセプト「つながり」と「発見」を明確に表現
- 2段落構成で読みやすさとメリハリを確保

## 改善効果
- より自然で親しみやすい日本語表現
- PCとモバイル両方のユーザーに配慮した表現
- NFC機能の明確な案内
- 簡潔さと情報量のバランスを最適化

## テスト計画
- [x] テキスト表示の確認
- [x] エスケープ文字が正しく表示されることを確認
- [x] 各デバイスでの表現の適切性を確認

🤖 Generated with [Claude Code](https://claude.ai/code)