### PR TITLE
🔧 fix: Android QRスキャナーのカメラ権限エラーとUIレイアウト問題を修正

### DIFF
--- a/src/components/prairie/PrairieCardInput.tsx
+++ b/src/components/prairie/PrairieCardInput.tsx
@@ -177,7 +177,7 @@ export default function PrairieCardInput({
             <label className="text-sm font-medium text-gray-300">
               {label}
             </label>
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-1 sm:gap-2 flex-nowrap">
               {/* Platform detection status (debug) */}
               {process.env.NODE_ENV === 'development' && (
                 <span className="text-xs text-gray-500 mr-2">
@@ -191,8 +191,8 @@ export default function PrairieCardInput({
                   type="button"
                   onClick={handleNFCScan}
                   className={`
-                    flex items-center gap-1.5 px-3 py-2 sm:px-3 sm:py-1.5 rounded-full text-sm font-medium
-                    transition-all duration-300 min-h-[44px] sm:min-h-0
+                    flex items-center gap-1 sm:gap-1.5 px-2 py-2 sm:px-3 sm:py-1.5 rounded-full text-xs sm:text-sm font-medium
+                    transition-all duration-300 min-h-[44px] sm:min-h-0 whitespace-nowrap flex-shrink-0
                     ${nfcScanning 
                       ? 'bg-blue-600 text-white' 
                       : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
@@ -214,8 +214,8 @@ export default function PrairieCardInput({
                   type="button"
                   onClick={handleQRScan}
                   className={`
-                    flex items-center gap-1.5 px-3 py-2 sm:px-3 sm:py-1.5 rounded-full text-sm font-medium
-                    transition-all duration-300 min-h-[44px] sm:min-h-0
+                    flex items-center gap-1 sm:gap-1.5 px-2 py-2 sm:px-3 sm:py-1.5 rounded-full text-xs sm:text-sm font-medium
+                    transition-all duration-300 min-h-[44px] sm:min-h-0 whitespace-nowrap flex-shrink-0
                     ${qrScanning || inputMethod === 'qr'
                       ? 'bg-purple-600 text-white' 
                       : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
@@ -236,9 +236,9 @@ export default function PrairieCardInput({
                 <motion.button
                   type="button"
                   onClick={handleClipboardPaste}
-                  className="flex items-center gap-1.5 px-3 py-2 sm:px-3 sm:py-1.5 rounded-full text-sm font-medium
+                  className="flex items-center gap-1 sm:gap-1.5 px-2 py-2 sm:px-3 sm:py-1.5 rounded-full text-xs sm:text-sm font-medium
                     bg-gray-700 text-gray-300 hover:bg-gray-600 transition-all duration-300
-                    min-h-[44px] sm:min-h-0"
+                    min-h-[44px] sm:min-h-0 whitespace-nowrap flex-shrink-0"
                   whileHover={{ scale: 1.05 }}
                   whileTap={{ scale: 0.95 }}
                   title="クリップボードから貼り付け"


### PR DESCRIPTION
## 概要
Androidデバイスで報告された2つの問題を修正しました：
1. QRコードスキャナーで権限が付与されているにも関わらず「アクセス拒否」エラーが表示される問題
2. Prairie Card入力画面で「貼付」ボタンが改行されてしまう問題

## 修正内容

### 1. 🎥 QRスキャナーのカメラ権限エラー改善
**問題**: Androidでカメラ権限を許可しているのに「カメラのアクセスが拒否されました」と表示される

**解決策**:
- **Permissions API事前チェック**: Android Chromeが対応している`navigator.permissions.query`を使用して権限状態を事前確認
- **SecurityErrorの適切な処理**: Android特有のセキュリティエラー（HTTPS要件など）を判別して適切なメッセージを表示
- **制約エラーのフォールバック**: `OverconstrainedError`発生時は、より単純な制約で再試行
- **エラーメッセージの改善**: より具体的で分かりやすいエラーメッセージを提供

### 2. 📱 UIボタンレイアウトの修正
**問題**: Androidスマートフォンで「貼付」ボタンが次の行に改行されてしまう

**解決策**:
- **強制1行表示**: `flex-nowrap`を追加してボタンの改行を防止
- **レスポンシブ調整**:
  - ボタン間隔: `gap-2` → `gap-1`（モバイル）
  - パディング: `px-3` → `px-2`（モバイル）
  - フォントサイズ: `text-sm` → `text-xs`（モバイル）
- **追加のスタイル**: `whitespace-nowrap`と`flex-shrink-0`で確実に1行表示

## テスト
- ✅ 全テストがパス
- ✅ TypeScript型チェックOK
- ✅ リントチェックOK

## 影響範囲
- `/src/hooks/useQRScanner.ts`: カメラ権限処理の改善
- `/src/components/prairie/PrairieCardInput.tsx`: ボタンレイアウトの最適化

## スクリーンショット
（実機でのテストが必要です）

## チェックリスト
- [x] コードの変更内容を確認した
- [x] テストがすべてパスすることを確認した
- [x] 関連するドキュメントの更新は不要
- [ ] Androidデバイスでの動作確認（レビュアーにお願いします）

🤖 Generated with [Claude Code](https://claude.ai/code)