### PR TITLE
🔧 fix: AndroidのQRスキャナー権限問題の根本的改善（v2）

### DIFF
--- a/src/components/prairie/PrairieCardInput.tsx
+++ b/src/components/prairie/PrairieCardInput.tsx
@@ -415,6 +415,20 @@ export default function PrairieCardInput({
                       Prairie Card のサーバーが応答していません。サンプルデータで診断機能をお試しいただけます。
                     </p>
                   )}
+                  {/* Android向けの追加ヘルプ */}
+                  {qrError && qrError.includes('カメラへのアクセスが拒否') && (
+                    <div className="mt-2 text-gray-400 text-sm space-y-1">
+                      <p className="font-semibold">Android端末でカメラが使えない場合：</p>
+                      <ol className="list-decimal list-inside space-y-1 ml-2">
+                        <li>ブラウザの設定を開く（Chrome: ⋮ → 設定）</li>
+                        <li>「サイトの設定」または「プライバシーとセキュリティ」を選択</li>
+                        <li>「カメラ」を選択</li>
+                        <li>このサイトを探して「許可」に変更</li>
+                        <li>ブラウザを再起動してから再試行</li>
+                      </ol>
+                      <p className="text-xs mt-2">それでも解決しない場合は、URLを直接入力するか、貼付ボタンをお使いください。</p>
+                    </div>
+                  )}
                 </div>
               </div>
               

--- a/src/hooks/useQRScanner.ts
+++ b/src/hooks/useQRScanner.ts
@@ -20,6 +20,15 @@ interface UseQRScannerReturn {
   clearError: () => void;
 }
 
+// Debug helper for Android issues
+function getDeviceInfo(): string {
+  const ua = navigator.userAgent;
+  const isAndroid = /Android/i.test(ua);
+  const isChrome = /Chrome/i.test(ua);
+  const version = ua.match(/Chrome\/(\d+)/)?.[1] || 'unknown';
+  return `Android: ${isAndroid}, Chrome: ${isChrome}, Version: ${version}`;
+}
+
 export function useQRScanner(): UseQRScannerReturn {
   const [isSupported, setIsSupported] = useState(false);
   const [isScanning, setIsScanning] = useState(false);
@@ -33,6 +42,9 @@ export function useQRScanner(): UseQRScannerReturn {
     // Check if camera API is supported
     if (navigator.mediaDevices && typeof navigator.mediaDevices.getUserMedia === 'function') {
       setIsSupported(true);
+      logger.debug('Camera API supported. Device info:', getDeviceInfo());
+    } else {
+      logger.error('Camera API not supported. Device info:', getDeviceInfo());
     }
   }, []);
 
@@ -96,84 +108,153 @@ export function useQRScanner(): UseQRScannerReturn {
       return;
     }
 
+    // Clear previous error and set scanning state
     setError(null);
     setIsScanning(true);
 
     try {
-      // Check permissions API if available (Android Chrome supports this)
-      if ('permissions' in navigator && 'query' in navigator.permissions) {
+      // Check if we're in a secure context (required for camera access)
+      if (!window.isSecureContext) {
+        logger.error('Not in secure context. Protocol:', window.location.protocol);
+        setError('HTTPSが必要です。安全な接続でアクセスしてください。');
+        setIsScanning(false);
+        return;
+      }
+
+      logger.debug('Starting camera access request...');
+      
+      // For Android, start with the simplest possible constraints
+      // and add complexity only if needed
+      let stream: MediaStream | null = null;
+      
+      // First attempt: Most basic request (works on most Android devices)
+      try {
+        logger.debug('Attempt 1: Basic video request');
+        stream = await navigator.mediaDevices.getUserMedia({
+          video: true
+        });
+        logger.debug('Success with basic video request');
+      } catch (basicErr) {
+        logger.debug('Basic request failed, trying with facingMode', basicErr);
+        
+        // Second attempt: Add facingMode as ideal (not exact)
         try {
-          const permissionStatus = await navigator.permissions.query({ name: 'camera' as PermissionName });
-          if (permissionStatus.state === 'denied') {
-            setError(CAMERA_ERROR_MESSAGES.PERMISSION_DENIED);
-            setIsScanning(false);
-            return;
+          logger.debug('Attempt 2: With ideal facingMode');
+          stream = await navigator.mediaDevices.getUserMedia({
+            video: {
+              facingMode: { ideal: 'environment' }
+            }
+          });
+          logger.debug('Success with ideal facingMode');
+        } catch (facingErr) {
+          logger.debug('FacingMode request failed, trying with string facingMode', facingErr);
+          
+          // Third attempt: Older syntax that some Android devices prefer
+          try {
+            logger.debug('Attempt 3: With string facingMode');
+            stream = await navigator.mediaDevices.getUserMedia({
+              video: {
+                facingMode: 'environment'
+              }
+            });
+            logger.debug('Success with string facingMode');
+          } catch (finalErr) {
+            // All attempts failed, throw the final error
+            throw finalErr;
           }
-        } catch (permError) {
-          // Permissions API might not support camera query, continue with getUserMedia
-          logger.debug('Permissions API camera query not supported', permError);
         }
       }
 
-      const stream = await navigator.mediaDevices.getUserMedia({
-        video: {
-          facingMode: 'environment', // Use back camera
-          width: { ideal: QR_CAMERA_WIDTH_IDEAL },
-          height: { ideal: QR_CAMERA_HEIGHT_IDEAL }
-        }
-      });
+      if (!stream) {
+        throw new Error('Failed to get media stream');
+      }
 
+      logger.debug('Got media stream successfully');
       streamRef.current = stream;
       
       if (videoRef.current) {
         videoRef.current.srcObject = stream;
+        
+        // Wait for video to be ready
+        await new Promise<void>((resolve, reject) => {
+          if (!videoRef.current) {
+            reject(new Error('Video element not found'));
+            return;
+          }
+          
+          const video = videoRef.current;
+          
+          // Set up event handlers
+          video.onloadedmetadata = () => {
+            logger.debug('Video metadata loaded');
+            resolve();
+          };
+          
+          video.onerror = (e) => {
+            logger.error('Video error:', e);
+            reject(new Error('Video playback error'));
+          };
+          
+          // Timeout after 5 seconds
+          setTimeout(() => {
+            reject(new Error('Video loading timeout'));
+          }, 5000);
+        });
+        
         await videoRef.current.play();
+        logger.debug('Video playback started successfully');
         
         // Start QR detection
         detectQRCode();
       }
     } catch (err) {
-      logger.error('Camera access error', err);
+      // Detailed error logging
+      const errorDetails = {
+        name: err instanceof Error ? err.name : 'Unknown',
+        message: err instanceof Error ? err.message : String(err),
+        deviceInfo: getDeviceInfo(),
+        secureContext: window.isSecureContext,
+        protocol: window.location.protocol
+      };
+      
+      logger.error('Camera access failed:', errorDetails);
       
       if (err instanceof Error) {
-        // Android Chrome may throw SecurityError for HTTPS requirement
-        if (err.name === 'SecurityError') {
-          // Check if it's actually a permission issue on Android
-          if (err.message.includes('Permission') || err.message.includes('permission')) {
-            setError(CAMERA_ERROR_MESSAGES.PERMISSION_DENIED);
+        // Handle specific error types
+        if (err.name === 'NotAllowedError' || err.name === 'PermissionDeniedError') {
+          // Most common on Android when permission is denied
+          setError('カメラへのアクセスが拒否されました。ブラウザの設定でこのサイトのカメラ権限を許可してください。');
+        } else if (err.name === 'SecurityError') {
+          // Can occur on insecure contexts or permission issues
+          if (err.message.toLowerCase().includes('permission')) {
+            setError('カメラ権限が必要です。ブラウザの設定を確認してください。');
           } else {
-            setError('セキュアな接続（HTTPS）が必要です。');
+            setError('セキュリティエラー：HTTPSでアクセスしてください。');
           }
-        } else if (err.name === 'NotAllowedError' || err.name === 'PermissionDeniedError') {
-          setError(CAMERA_ERROR_MESSAGES.PERMISSION_DENIED);
         } else if (err.name === 'NotFoundError' || err.name === 'DevicesNotFoundError') {
-          setError(CAMERA_ERROR_MESSAGES.NOT_FOUND);
+          setError('カメラが見つかりません。デバイスにカメラが接続されているか確認してください。');
         } else if (err.name === 'NotReadableError' || err.name === 'TrackStartError') {
-          setError(CAMERA_ERROR_MESSAGES.IN_USE);
+          setError('カメラが他のアプリで使用中です。他のアプリを閉じてから再試行してください。');
         } else if (err.name === 'OverconstrainedError' || err.name === 'ConstraintNotSatisfiedError') {
-          // Try again with simpler constraints for Android compatibility
-          try {
-            const simpleStream = await navigator.mediaDevices.getUserMedia({
-              video: { facingMode: 'environment' }
-            });
-            streamRef.current = simpleStream;
-            if (videoRef.current) {
-              videoRef.current.srcObject = simpleStream;
-              await videoRef.current.play();
-              detectQRCode();
-              return;
-            }
-          } catch (retryErr) {
-            setError(CAMERA_ERROR_MESSAGES.GENERIC);
-          }
+          setError('カメラの設定に問題があります。別のブラウザで試してください。');
+        } else if (err.name === 'TypeError') {
+          setError('ブラウザがカメラアクセスをサポートしていません。');
+        } else if (err.message.includes('timeout')) {
+          setError('カメラの起動がタイムアウトしました。再試行してください。');
         } else {
-          setError(`カメラアクセスエラー: ${err.message}`);
+          setError(`カメラエラー: ${err.message}`);
         }
       } else {
         setError(CAMERA_ERROR_MESSAGES.GENERIC);
       }
       
       setIsScanning(false);
+      
+      // Clean up any partial stream
+      if (streamRef.current) {
+        streamRef.current.getTracks().forEach(track => track.stop());
+        streamRef.current = null;
+      }
     }
   }, [isSupported, detectQRCode]);
 


### PR DESCRIPTION
## 概要
前回のPR #233ではAndroidのQRスキャナー問題が解決しなかったため、より根本的な改善を実施しました。

## 問題
- Androidデバイスでカメラ権限を許可しているにも関わらず「アクセス拒否」エラーが表示される
- 様々なAndroidデバイスで異なるエラーが発生

## 解決策

### 1. 🎯 3段階フォールバック戦略
Android端末の多様性に対応するため、段階的にカメラアクセスを試行：

```javascript
// 第1段階: 最もシンプルな要求
{ video: true }

// 第2段階: ideal制約を使用
{ video: { facingMode: { ideal: 'environment' } } }

// 第3段階: 古い構文（一部のAndroidで必要）
{ video: { facingMode: 'environment' } }
```

### 2. 📊 詳細なデバッグ情報
- デバイス情報（Android/Chrome/バージョン）の記録
- HTTPSコンテキストの確認
- 各段階での詳細ログ出力
- エラー詳細の収集と分析

### 3. ⏱️ タイムアウトとエラー処理
- ビデオ読み込みタイムアウト（5秒）
- メタデータ読み込み待機
- より具体的なエラーメッセージ

### 4. 📱 Android向けUIヘルプ
エラー時に表示される詳細な手順：
1. ブラウザの設定を開く（Chrome: ⋮ → 設定）
2. 「サイトの設定」または「プライバシーとセキュリティ」を選択
3. 「カメラ」を選択
4. このサイトを探して「許可」に変更
5. ブラウザを再起動してから再試行

## テスト
- ✅ 全テストがパス
- ✅ TypeScript型チェックOK
- ✅ リントチェックOK

## 影響範囲
- `/src/hooks/useQRScanner.ts`: カメラアクセスロジックの全面改良
- `/src/components/prairie/PrairieCardInput.tsx`: Android向けヘルプ情報追加

## チェックリスト
- [x] コードの変更内容を確認した
- [x] テストがすべてパスすることを確認した
- [x] 関連するドキュメントの更新は不要
- [ ] Androidデバイスでの動作確認（レビュアーにお願いします）

## 注記
この修正により、より多くのAndroidデバイスでQRスキャナーが動作するようになるはずです。
それでも問題が解決しない場合は、URL直接入力または貼付ボタンの使用を推奨します。

🤖 Generated with [Claude Code](https://claude.ai/code)