### PR TITLE
🔍 fix: AndroidのQRスキャナー権限問題の詳細なデバッグ機能を追加 (#236)

### DIFF
--- a/src/components/prairie/PrairieCardInput.tsx
+++ b/src/components/prairie/PrairieCardInput.tsx
@@ -181,11 +181,13 @@ export default function PrairieCardInput({
               {label}
             </label>
             <div className="flex items-center gap-1 sm:gap-2 flex-nowrap">
-              {/* Platform detection status (debug) */}
-              {process.env.NODE_ENV === 'development' && (
-                <span className="text-xs text-gray-500 mr-2">
-                  Platform: {platform}
-                </span>
+              {/* Debug information (development or debug mode) */}
+              {(process.env.NODE_ENV === 'development' || (typeof window !== 'undefined' && window.location.search.includes('debug=true'))) && (
+                <div className="text-xs text-gray-500 mr-2 flex flex-col items-end">
+                  <span>Platform: {platform}</span>
+                  <span>Permission: {permissionState}</span>
+                  <span>Scanner: {scannerType}</span>
+                </div>
               )}
               
               {/* NFC Button (Android only) */}
@@ -534,6 +536,70 @@ export default function PrairieCardInput({
             'Prairie Cardを読み込む'
           )}
         </motion.button>
+
+        {/* Camera Permission Test Button (Debug Mode Only) */}
+        {(process.env.NODE_ENV === 'development' || (typeof window !== 'undefined' && window.location.search.includes('debug=true'))) && (
+          <div className="mt-4 p-4 bg-gray-800/50 rounded-xl border border-gray-700">
+            <p className="text-sm text-gray-400 mb-2">🔧 デバッグツール</p>
+            <motion.button
+              type="button"
+              onClick={async () => {
+                console.group('📷 Camera Permission Test');
+                console.log('Starting camera permission test...');
+                const startTime = Date.now();
+                
+                try {
+                  // Check if in secure context
+                  console.log('Secure Context:', window.isSecureContext);
+                  console.log('Protocol:', window.location.protocol);
+                  console.log('Hostname:', window.location.hostname);
+                  
+                  // Check Permissions API
+                  if ('permissions' in navigator) {
+                    try {
+                      const result = await navigator.permissions.query({ name: 'camera' as PermissionName });
+                      console.log('Current Permission State:', result.state);
+                    } catch (e) {
+                      console.log('Permission Query Failed:', e);
+                    }
+                  }
+                  
+                  // Try to get user media
+                  console.log('Calling getUserMedia...');
+                  const stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: false });
+                  const elapsed = Date.now() - startTime;
+                  console.log(`✅ Success! Got camera stream in ${elapsed}ms`);
+                  
+                  // Clean up
+                  stream.getTracks().forEach(track => track.stop());
+                  
+                  alert(`カメラアクセス成功！\n所要時間: ${elapsed}ms`);
+                } catch (error) {
+                  const elapsed = Date.now() - startTime;
+                  console.error('❌ Camera Test Failed:', {
+                    name: (error as Error).name,
+                    message: (error as Error).message,
+                    elapsed: `${elapsed}ms`
+                  });
+                  
+                  alert(`カメラアクセス失敗\n\nエラー: ${(error as Error).name}\nメッセージ: ${(error as Error).message}\n所要時間: ${elapsed}ms`);
+                }
+                
+                console.groupEnd();
+              }}
+              className="w-full py-2 px-4 bg-yellow-600 hover:bg-yellow-700 text-white rounded-lg
+                font-medium transition-colors flex items-center justify-center gap-2"
+              whileHover={{ scale: 1.02 }}
+              whileTap={{ scale: 0.98 }}
+            >
+              📷 カメラ権限テスト
+            </motion.button>
+            <p className="text-xs text-gray-500 mt-2">
+              このボタンでカメラ権限の直接テストができます。
+              コンソールに詳細なログが出力されます。
+            </p>
+          </div>
+        )}
       </form>
     </motion.div>
   );

--- a/src/components/prairie/PrairieCardInput.tsx
+++ b/src/components/prairie/PrairieCardInput.tsx
@@ -9,6 +9,7 @@ import { useQRScannerV2 } from "@/hooks/useQRScannerV2";
 import { useClipboardPaste } from "@/hooks/useClipboardPaste";
 import { PrairieProfile } from "@/types";
 import { detectPlatform } from "@/lib/platform";
+import { isDebugMode } from "@/constants/debug";
 import { Loader2, Check, AlertCircle, User, Smartphone, X, QrCode, Clipboard, Camera } from "lucide-react";
 
 interface PrairieCardInputProps {
@@ -182,7 +183,7 @@ export default function PrairieCardInput({
             </label>
             <div className="flex items-center gap-1 sm:gap-2 flex-nowrap">
               {/* Debug information (development or debug mode) */}
-              {(process.env.NODE_ENV === 'development' || (typeof window !== 'undefined' && window.location.search.includes('debug=true'))) && (
+              {isDebugMode() && (
                 <div className="text-xs text-gray-500 mr-2 flex flex-col items-end">
                   <span>Platform: {platform}</span>
                   <span>Permission: {permissionState}</span>
@@ -538,7 +539,7 @@ export default function PrairieCardInput({
         </motion.button>
 
         {/* Camera Permission Test Button (Debug Mode Only) */}
-        {(process.env.NODE_ENV === 'development' || (typeof window !== 'undefined' && window.location.search.includes('debug=true'))) && (
+        {isDebugMode() && (
           <div className="mt-4 p-4 bg-gray-800/50 rounded-xl border border-gray-700">
             <p className="text-sm text-gray-400 mb-2">🔧 デバッグツール</p>
             <motion.button

--- a/src/constants/debug.ts
+++ b/src/constants/debug.ts
@@ -1,0 +1,54 @@
+/**
+ * Debug-related constants
+ */
+
+export const DEBUG_CONSTANTS = {
+  /**
+   * Threshold in milliseconds to determine if an error occurred too quickly
+   * (likely due to browser/policy blocking rather than user denial)
+   */
+  QUICK_ERROR_THRESHOLD_MS: 1000,
+  
+  /**
+   * Timeout for camera test operations
+   */
+  CAMERA_TEST_TIMEOUT_MS: 5000,
+  
+  /**
+   * Query parameter name for debug mode
+   */
+  DEBUG_QUERY_PARAM: 'debug',
+  
+  /**
+   * Video loading timeout for QR scanner
+   */
+  VIDEO_LOADING_TIMEOUT_MS: 5000,
+} as const;
+
+/**
+ * Check if debug mode is enabled
+ */
+export function isDebugMode(): boolean {
+  // Always allow in development
+  if (process.env.NODE_ENV === 'development') return true;
+  
+  // Check for debug query parameter in production
+  if (typeof window !== 'undefined') {
+    const params = new URLSearchParams(window.location.search);
+    return params.has(DEBUG_CONSTANTS.DEBUG_QUERY_PARAM) && 
+           params.get(DEBUG_CONSTANTS.DEBUG_QUERY_PARAM) === 'true';
+  }
+  
+  return false;
+}
+
+/**
+ * Sanitize URL by masking sensitive query parameters
+ */
+export function sanitizeUrl(url: string): string {
+  return url
+    .replace(/([?&]token=)[^&]*/g, '$1***')
+    .replace(/([?&]api[_-]?key=)[^&]*/gi, '$1***')
+    .replace(/([?&]secret=)[^&]*/gi, '$1***')
+    .replace(/([?&]password=)[^&]*/gi, '$1***');
+}


### PR DESCRIPTION
## 概要
AndroidでQRボタンをクリックすると、カメラ権限ダイアログが表示されずに即座にエラーになる問題を調査するための詳細なデバッグ機能を追加しました。

## 問題の詳細
ユーザーの報告:
- QRボタンクリック時、権限ダイアログが一度も表示されない
- エラーが即座（1秒未満）に表示される
- Chrome設定にサイトが表示されない（権限を求められたことがないため）

## 実装した機能

### 1. 詳細なデバッグログ
- getUserMedia呼び出し前後のタイミング計測
- Permissions Policy/Feature Policyの状態チェック
- 権限状態の事前チェック（prompt/granted/denied）
- エラー時のスタックトレース記録

### 2. 自動診断機能
- エラー発生時間が1秒未満の場合、ブラウザ/ポリシーによるブロックと判定
- より詳細なエラーメッセージとトラブルシューティングガイドを表示

### 3. デバッグツール
- URLに`?debug=true`を追加すると詳細情報を表示
- カメラ権限テストボタン（開発/デバッグモードのみ）
- 権限状態、スキャナータイプ、プラットフォーム情報の可視化

## テスト方法
1. Android ChromeでアプリにアクセスしてQRボタンをクリック
2. コンソールログを確認（F12 → Console）
3. デバッグモード: `?debug=true`をURLに追加
4. カメラ権限テストボタンでgetUserMediaの直接テスト

## 期待される成果
この変更により、以下の情報が明確になります:
- getUserMediaがどの段階で失敗するか
- Feature Policy/Permissions Policyによるブロックの有無
- Cloudflare Pagesのドメイン制限の影響
- 真の原因の特定と適切な回避策の提示

🔧 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>