### PR TITLE
fix: メトリクスダッシュボードリンク削除とイベントサイトリンク追加

### DIFF
--- a/src/app/duo/results/page.tsx
+++ b/src/app/duo/results/page.tsx
@@ -406,13 +406,20 @@ export default function ResultsPage() {
           transition={{ delay: 1.5 }}
           className="flex flex-col items-center gap-4 mt-16 pt-8 border-t border-gray-700/50"
         >
-          <Image
-            src="/images/trademark@4x.png"
-            alt="CloudNative Days Winter 2025"
-            width={80}
-            height={20}
-            className="opacity-90"
-          />
+          <Link
+            href="https://event.cloudnativedays.jp/cndw2025"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group inline-block"
+          >
+            <Image
+              src="/images/trademark@4x.png"
+              alt="CloudNative Days Winter 2025"
+              width={80}
+              height={20}
+              className="opacity-90 group-hover:opacity-100 transition-opacity duration-300"
+            />
+          </Link>
           <p className="text-sm md:text-base text-purple-400 font-medium">
             #CNDxCnD
           </p>

--- a/src/app/duo/results/page.tsx
+++ b/src/app/duo/results/page.tsx
@@ -411,6 +411,7 @@ export default function ResultsPage() {
             target="_blank"
             rel="noopener noreferrer"
             className="group inline-block"
+            aria-label="CloudNative Days Winter 2025 イベントサイトへ移動（新しいタブで開きます）"
           >
             <Image
               src="/images/trademark@4x.png"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,6 @@ import { AppDescription } from "@/components/landing/AppDescription";
 import { DiagnosisResult as DiagnosisResultComponent } from "@/components/diagnosis/DiagnosisResult";
 import type { DiagnosisResult, ResultApiResponse } from "@/types";
 import { sanitizer } from "@/lib/sanitizer";
-import { BarChart3 } from "lucide-react";
 
 // Constants
 const LOADING_SCREEN_DURATION = 1000;
@@ -435,22 +434,6 @@ export default function Home() {
           </motion.div>
         </AnimatePresence>
 
-        {/* Admin Link */}
-        <motion.div
-          className="absolute top-4 right-4"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ delay: 0.5 }}
-        >
-          <Link
-            href="/admin/metrics"
-            className="flex items-center gap-2 px-4 py-2 bg-gray-800/50 hover:bg-gray-700/50 rounded-lg transition-colors text-gray-400 hover:text-white"
-          >
-            <BarChart3 className="w-4 h-4" />
-            <span className="text-sm">Metrics</span>
-          </Link>
-        </motion.div>
-
         {/* フッター with CloudNative Days Logo and Hashtag */}
         <motion.div
           className="text-center"
@@ -459,13 +442,20 @@ export default function Home() {
           transition={{ delay: 0.8 }}
         >
           <div className="flex flex-col items-center gap-4">
-            <Image
-              src="/images/trademark@4x.png"
-              alt="CloudNative Days Winter 2025"
-              width={80}
-              height={80}
-              className="opacity-80 hover:opacity-100 transition-opacity"
-            />
+            <Link
+              href="https://event.cloudnativedays.jp/cndw2025"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group inline-block"
+            >
+              <Image
+                src="/images/trademark@4x.png"
+                alt="CloudNative Days Winter 2025"
+                width={80}
+                height={80}
+                className="opacity-80 group-hover:opacity-100 transition-opacity duration-300"
+              />
+            </Link>
             <p className="text-sm md:text-base text-purple-400 font-medium">
               #CNDxCnD
             </p>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -447,6 +447,7 @@ export default function Home() {
               target="_blank"
               rel="noopener noreferrer"
               className="group inline-block"
+              aria-label="CloudNative Days Winter 2025 イベントサイトへ移動（新しいタブで開きます）"
             >
               <Image
                 src="/images/trademark@4x.png"

--- a/src/components/diagnosis/AstrologicalDiagnosisResult.tsx
+++ b/src/components/diagnosis/AstrologicalDiagnosisResult.tsx
@@ -6,6 +6,7 @@ import { Star, Sparkles, Users, MessageCircle, Zap, Trophy, Gift, Target } from 
 import { useState, useEffect } from "react";
 import Confetti from "react-confetti";
 import Image from "next/image";
+import Link from "next/link";
 
 interface AstrologicalDiagnosisResultProps {
   result: DiagnosisResult;
@@ -268,13 +269,20 @@ export function AstrologicalDiagnosisResult({ result, onReset }: AstrologicalDia
           transition={{ delay: 1.1 }}
           className="flex flex-col items-center gap-4 pt-8 border-t border-gray-700"
         >
-          <Image
-            src="/images/trademark@4x.png"
-            alt="CloudNative Days Winter 2025"
-            width={80}
-            height={20}
-            className="opacity-90"
-          />
+          <Link
+            href="https://event.cloudnativedays.jp/cndw2025"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group inline-block"
+          >
+            <Image
+              src="/images/trademark@4x.png"
+              alt="CloudNative Days Winter 2025"
+              width={80}
+              height={20}
+              className="opacity-90 group-hover:opacity-100 transition-opacity duration-300"
+            />
+          </Link>
           <p className="text-sm md:text-base text-purple-400 font-medium">
             #CNDxCnD
           </p>

--- a/src/components/diagnosis/AstrologicalDiagnosisResult.tsx
+++ b/src/components/diagnosis/AstrologicalDiagnosisResult.tsx
@@ -274,6 +274,7 @@ export function AstrologicalDiagnosisResult({ result, onReset }: AstrologicalDia
             target="_blank"
             rel="noopener noreferrer"
             className="group inline-block"
+            aria-label="CloudNative Days Winter 2025 イベントサイトへ移動（新しいタブで開きます）"
           >
             <Image
               src="/images/trademark@4x.png"


### PR DESCRIPTION
## 🔧 概要
トップページのUI改善として以下の変更を実施しました：

1. **メトリクスダッシュボードへのリンクを削除**
   - 一般参加者には不要な機能のため削除
   - 管理者用機能は別途アクセス方法を検討

2. **CloudNative Days Winter 2025イベントサイトへのリンク追加**
   - トレードマーク画像からリンク可能に
   - https://event.cloudnativedays.jp/cndw2025 へ新しいタブで開く
   - ホバー時のアニメーション効果付き

## 📝 変更内容

### 削除した要素
- `/admin/metrics`へのリンクボタン
- BarChart3アイコンのインポート

### 追加した要素
- トレードマーク画像にLinkコンポーネントでラップ
- `target="_blank"`と`rel="noopener noreferrer"`を設定
- ホバー時の視覚的フィードバック（opacity変更）

## ✅ 動作確認
- [x] メトリクスリンクが削除されていることを確認
- [x] トレードマーク画像からイベントサイトへリンクできることを確認
- [x] 新しいタブで開くことを確認
- [x] ホバー時のアニメーションが動作することを確認

## 📸 スクリーンショット
- Before: 右上にMetricsボタンが表示されていた
- After: ボタンが削除され、トレードマーク画像がクリッカブルに

🤖 Generated with [Claude Code](https://claude.ai/code)