### PR TITLE
🔧 fix: Android ChromeでQRスキャナーのカメラ権限が拒否される問題を修正

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -3,7 +3,7 @@
   X-Content-Type-Options: nosniff
   X-XSS-Protection: 1; mode=block
   Referrer-Policy: strict-origin-when-cross-origin
-  Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()
+  Permissions-Policy: camera=(self), microphone=(), geolocation=(), payment=()
   Content-Security-Policy: default-src 'self' https://cnd2-app.pages.dev https://cnd2.cloudnativedays.jp; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cnd2-app.pages.dev https://cnd2.cloudnativedays.jp https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cnd2-app.pages.dev https://cnd2.cloudnativedays.jp https://fonts.googleapis.com; font-src 'self' https://cnd2-app.pages.dev https://cnd2.cloudnativedays.jp https://fonts.gstatic.com data:; img-src 'self' data: https: blob:; connect-src 'self' https://cnd2-app.pages.dev https://cnd2.cloudnativedays.jp https://api.openai.com https://prairie.cards https://*.prairie.cards https://api.qrserver.com; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;
 
 /api/*

--- a/src/__tests__/csp-headers.test.ts
+++ b/src/__tests__/csp-headers.test.ts
@@ -108,7 +108,7 @@ describe('CSP Headers Configuration', () => {
 
       it('should have Permissions-Policy header', () => {
         expect(rootHeaders).toContain('Permissions-Policy:');
-        expect(rootHeaders).toContain('camera=()');
+        expect(rootHeaders).toContain('camera=(self)');
         expect(rootHeaders).toContain('microphone=()');
         expect(rootHeaders).toContain('geolocation=()');
       });


### PR DESCRIPTION
## 概要
Android ChromeでQRスキャナーのカメラアクセスが即座に拒否される問題を修正しました。

## 問題
- Android Chromeで「NotAllowedError」が59msで発生
- カメラ権限ダイアログが表示されない
- iOS ChromeとAndroid Firefoxは正常動作

## 原因
`public/_headers`ファイルで以下の設定がカメラを完全ブロックしていました：
```
Permissions-Policy: camera=()
```

- `camera=()` は「どのオリジンからもカメラ使用不可」という意味
- Android Chromeはこのポリシーを厳格に適用
- FirefoxやiOS Chromeは無視または緩い解釈

## 解決策
```diff
- Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()
+ Permissions-Policy: camera=(self), microphone=(), geolocation=(), payment=()
```

- `camera=(self)`: 同一オリジンからのカメラアクセスを許可
- セキュリティは維持（microphone、geolocation、paymentは引き続きブロック）

## テスト
- [ ] Android ChromeでQRスキャナーが動作することを確認
- [ ] iOS ChromeとAndroid Firefoxで引き続き動作することを確認
- [ ] デプロイ後、本番環境でも動作確認

## 関連Issue
- Android QRスキャナー問題の詳細デバッグ (#238, #240)