### PR TITLE
🚨 fix: TypeScriptエラーを修正 - stopScan関数の定義順序

### DIFF
--- a/src/hooks/useQRScannerV2.ts
+++ b/src/hooks/useQRScannerV2.ts
@@ -221,6 +221,39 @@ export function useQRScannerV2(): UseQRScannerReturn {
     }
   }, [isScanning]);
 
+  // Stop scanning - Define before other functions that use it
+  const stopScan = useCallback(() => {
+    logger.debug('Stopping QR scanner');
+    setIsScanning(false);
+    
+    // Stop qr-scanner if active
+    if (qrScannerRef.current) {
+      qrScannerRef.current.stop();
+      qrScannerRef.current.destroy();
+      qrScannerRef.current = null;
+    }
+    
+    // Clear BarcodeDetector
+    barcodeDetectorRef.current = null;
+    
+    // Stop camera stream
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach(track => track.stop());
+      streamRef.current = null;
+    }
+    
+    // Clear video
+    if (videoRef.current) {
+      videoRef.current.srcObject = null;
+    }
+    
+    // Cancel scan timeout
+    if (scanTimeoutRef.current) {
+      clearTimeout(scanTimeoutRef.current);
+      scanTimeoutRef.current = null;
+    }
+  }, []);
+
   // Handle Android Chrome camera access
   const handleAndroidChromeCamera = useCallback(async (): Promise<MediaStream | null> => {
     logger.debug('Android Chrome detected - calling getUserMedia immediately to preserve user gesture');
@@ -548,39 +581,6 @@ export function useQRScannerV2(): UseQRScannerReturn {
       handleCameraError(err as Error, startTime);
     }
   }, [isSupported, scannerType, permissionState, detectWithBarcodeDetector, deviceInfo, handleAndroidChromeCamera, setupVideoAndStartDetection, handleCameraError, stopScan]);
-
-  // Stop scanning
-  const stopScan = useCallback(() => {
-    logger.debug('Stopping QR scanner');
-    setIsScanning(false);
-    
-    // Stop qr-scanner if active
-    if (qrScannerRef.current) {
-      qrScannerRef.current.stop();
-      qrScannerRef.current.destroy();
-      qrScannerRef.current = null;
-    }
-    
-    // Clear BarcodeDetector
-    barcodeDetectorRef.current = null;
-    
-    // Stop camera stream
-    if (streamRef.current) {
-      streamRef.current.getTracks().forEach(track => track.stop());
-      streamRef.current = null;
-    }
-    
-    // Clear video
-    if (videoRef.current) {
-      videoRef.current.srcObject = null;
-    }
-    
-    // Cancel scan timeout
-    if (scanTimeoutRef.current) {
-      clearTimeout(scanTimeoutRef.current);
-      scanTimeoutRef.current = null;
-    }
-  }, []);
 
   // Clear error
   const clearError = useCallback(() => {


### PR DESCRIPTION
## 🐛 問題

PR #243マージ後のデプロイで以下のTypeScriptエラーが発生:
```
error TS2448: Block-scoped variable 'stopScan' used before its declaration.
error TS2454: Variable 'stopScan' is used before being assigned.
```

## 🔧 修正内容

- `stopScan`関数を他の関数より前に定義
- 関数が宣言される前に依存配列で使用される問題を解決

## ✅ 確認事項

- [ ] TypeScriptエラーが解決（`npm run type-check`でエラーなし）
- [ ] デプロイが正常に完了