### PR TITLE
📷 fix: Android Chromeで背面カメラを優先的に使用

### DIFF
--- a/src/hooks/useQRScannerV2.ts
+++ b/src/hooks/useQRScannerV2.ts
@@ -260,14 +260,25 @@ export function useQRScannerV2(): UseQRScannerReturn {
     
     try {
       // 即座にgetUserMediaを呼んでユーザージェスチャーを保持
-      // Android Chromeでは最もシンプルな制約を使用（facingModeが問題を引き起こす可能性）
-      const stream = await navigator.mediaDevices.getUserMedia({
-        video: true,  // 最もシンプルな制約
-        audio: false
-      });
-      
-      logger.debug('Got camera stream successfully on Android Chrome');
-      return stream;
+      // まず背面カメラを試みる
+      try {
+        logger.debug('Trying rear camera (environment) first...');
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: { facingMode: 'environment' },  // 背面カメラを指定
+          audio: false
+        });
+        logger.debug('Got rear camera stream successfully on Android Chrome');
+        return stream;
+      } catch (err1) {
+        logger.debug('Rear camera failed, trying any available camera...');
+        // 背面カメラが失敗した場合は、どのカメラでも受け入れる
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: true,  // フォールバック：利用可能な任意のカメラ
+          audio: false
+        });
+        logger.debug('Got camera stream successfully on Android Chrome (fallback)');
+        return stream;
+      }
     } catch (err) {
       logger.error('Android Chrome camera access failed:', err);
       throw err;


### PR DESCRIPTION
## 📱 問題

Android ChromeでQRスキャナーが動作するようになったが、フロントカメラが起動していた。

## 🔧 修正内容

`handleAndroidChromeCamera`関数を改善：

1. **背面カメラを優先**
   - `facingMode: 'environment'`で背面カメラを指定
   - QRコード読み取りには背面カメラが適切

2. **フォールバック処理**
   - 背面カメラが利用できない場合は`video: true`で任意のカメラを使用
   - デバイスによっては背面カメラがない場合もあるため

## 📝 実装詳細

```javascript
// まず背面カメラを試みる
video: { facingMode: 'environment' }

// 失敗した場合のフォールバック
video: true
```

## ✅ テスト手順

1. Android ChromeでQRスキャナーボタンをクリック
2. **背面カメラ**が起動することを確認
3. QRコードが正常に読み取れることを確認

## 🎯 期待される効果

- Android Chromeで背面カメラが優先的に使用される
- QRコードの読み取りが容易になる
- 背面カメラがない端末でも動作する（フォールバック）